### PR TITLE
Fix OECD compliance mapper risk category

### DIFF
--- a/apps/backend/src/application/services/compliance_mapper.py
+++ b/apps/backend/src/application/services/compliance_mapper.py
@@ -4,7 +4,6 @@ Maps policies to multiple regulatory frameworks and provides automated complianc
 """
 
 import json
-import yaml
 from typing import Dict, List, Any, Optional, Set, Tuple
 from dataclasses import dataclass, asdict
 from datetime import datetime
@@ -16,6 +15,7 @@ logger = logging.getLogger(__name__)
 class RiskCategory(Enum):
     PROHIBITED = "prohibited"
     HIGH_RISK = "high_risk"
+    MEDIUM_RISK = "medium_risk"
     LIMITED_RISK = "limited_risk"
     MINIMAL_RISK = "minimal_risk"
 

--- a/tests/test_oecd_compliance_mapper.py
+++ b/tests/test_oecd_compliance_mapper.py
@@ -1,0 +1,25 @@
+from src.application.services.compliance_mapper import ComplianceMapper, RiskCategory
+
+
+def test_oecd_framework_loads_expected_controls():
+    mapper = ComplianceMapper()
+
+    oecd_controls = mapper.get_framework_controls("oecd_ai_principles")
+
+    assert set(oecd_controls) >= {"inclusive_1", "human_1"}
+    assert oecd_controls["inclusive_1"].framework == "oecd_ai_principles"
+    assert oecd_controls["inclusive_1"].risk_level is RiskCategory.MEDIUM_RISK
+    assert "impact_assessments" in oecd_controls["inclusive_1"].evidence_types
+
+
+def test_oecd_policy_maps_to_oecd_controls():
+    mapper = ComplianceMapper()
+
+    mapping = mapper.map_policy_to_frameworks(
+        "policy-oecd-human-oversight",
+        "AI systems must respect human autonomy, enable human oversight, and document transparency.",
+        {"framework": "oecd_ai_principles"},
+    )
+
+    assert "human_1" in mapping.regulatory_controls
+    assert mapping.mapping_confidence > 0


### PR DESCRIPTION
# Fix OECD compliance mapper risk category

## Summary

- Add the missing `MEDIUM_RISK` enum value used by OECD and local regulation controls.
- Remove the unused `yaml` import from `compliance_mapper.py` so the mapper can load without requiring an undeclared dependency.
- Add focused tests for OECD AI Principles control loading and policy-to-control mapping.

## Related issue

- Helps #151

## Verification

```bash
python -m pytest tests/test_oecd_compliance_mapper.py
```

Result: `2 passed`.

AANA local guardrail: PASS for code-change review with `candidate_gate=pass` and `recommended_action=accept`.
