### PR TITLE
[codex] Surface AIBOM fairness evidence profile

### DIFF
--- a/apps/backend/src/api/routers/real_ai_bom.py
+++ b/apps/backend/src/api/routers/real_ai_bom.py
@@ -4,7 +4,7 @@ Replaces mock endpoints with actual database operations
 """
 
 from fastapi import APIRouter, HTTPException, Query, Depends
-from typing import List, Optional
+from typing import Any, Mapping, List, Optional
 import logging
 from datetime import datetime
 
@@ -13,6 +13,9 @@ from ..models.ai_bom import (
     AIBOMComponent, ComponentType, RiskLevel, ComplianceStatus
 )
 from ..services.real_ai_bom_service import RealAIBOMService
+from src.application.services.fairness_evidence_profile_service import (
+    FairnessEvidenceProfileService,
+)
 
 router = APIRouter(prefix="/ai-bom", tags=["ai-bom"])
 
@@ -20,6 +23,74 @@ logger = logging.getLogger(__name__)
 
 # Initialize the real AI BOM service
 ai_bom_service = RealAIBOMService()
+fairness_profile_service = FairnessEvidenceProfileService()
+
+
+def _to_mapping(value: Any) -> Mapping[str, Any]:
+    """Convert Pydantic models or dict-like values into plain mappings."""
+    if isinstance(value, Mapping):
+        return value
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    if hasattr(value, "dict"):
+        return value.dict()
+    return {}
+
+
+def _component_metadata(component: Any) -> Mapping[str, Any]:
+    component_mapping = _to_mapping(component)
+    metadata = component_mapping.get("component_metadata") or {}
+    return metadata if isinstance(metadata, Mapping) else {}
+
+
+def _fairness_profile_inputs(document: Any) -> dict[str, Any]:
+    """Extract optional FairMind fairness evidence attached to AIBOM metadata."""
+    bias_results: dict[str, dict[str, Any]] = {}
+    evidence_records: dict[str, dict[str, Any]] = {}
+    remediation_records: dict[str, list[Mapping[str, Any]]] = {}
+
+    document_mapping = _to_mapping(document)
+    for component in document_mapping.get("components", []) or []:
+        component_mapping = _to_mapping(component)
+        component_id = (
+            component_mapping.get("component_id")
+            or component_mapping.get("id")
+            or component_mapping.get("name")
+        )
+        if not component_id:
+            continue
+
+        metadata = _component_metadata(component_mapping)
+        evidence = metadata.get("fairness_evidence")
+        bias_result = metadata.get("bias_result")
+        remediation_history = metadata.get("remediation_history")
+
+        if isinstance(evidence, Mapping):
+            evidence_records[str(component_id)] = dict(evidence)
+        if isinstance(bias_result, Mapping):
+            bias_results[str(component_id)] = dict(bias_result)
+        if isinstance(remediation_history, list):
+            remediation_records[str(component_id)] = [
+                remediation
+                for remediation in remediation_history
+                if isinstance(remediation, Mapping)
+            ]
+
+    return {
+        "bias_results": bias_results,
+        "evidence_records": evidence_records,
+        "remediation_records": remediation_records,
+    }
+
+
+def _fairness_review_state(document: Any) -> Mapping[str, Any]:
+    document_mapping = _to_mapping(document)
+    risk_assessment = document_mapping.get("risk_assessment") or {}
+    if not isinstance(risk_assessment, Mapping):
+        return {}
+
+    review_state = risk_assessment.get("fairness_review_state") or {}
+    return review_state if isinstance(review_state, Mapping) else {}
 
 @router.post("/create", response_model=AIBOMResponse)
 async def create_ai_bom(request: AIBOMRequest):
@@ -101,6 +172,36 @@ async def get_ai_bom_document(bom_id: str):
         logger.error(f"Error getting AI BOM document: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
+@router.get("/documents/{bom_id}/fairness-evidence-profile", response_model=AIBOMResponse)
+async def get_fairness_evidence_profile(bom_id: str):
+    """Generate a reviewer-facing fairness evidence profile for an AI BOM document"""
+    try:
+        document = ai_bom_service.get_bom_document(bom_id)
+
+        if not document:
+            raise HTTPException(status_code=404, detail="AI BOM document not found")
+
+        profile_inputs = _fairness_profile_inputs(document)
+        profile = fairness_profile_service.generate_profile(
+            bom_document=_to_mapping(document),
+            bias_results=profile_inputs["bias_results"],
+            evidence_records=profile_inputs["evidence_records"],
+            remediation_records=profile_inputs["remediation_records"],
+            review_state=_fairness_review_state(document),
+        )
+
+        return AIBOMResponse(
+            success=True,
+            data=profile,
+            message=f"Fairness evidence profile generated successfully: {bom_id}",
+            timestamp=datetime.now()
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error generating fairness evidence profile: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
 @router.put("/documents/{bom_id}", response_model=AIBOMResponse)
 async def update_ai_bom_document(bom_id: str, request: AIBOMRequest):
     """Update an AI BOM document"""
@@ -168,5 +269,3 @@ async def health_check():
         "database": "connected",
         "timestamp": datetime.now().isoformat()
     }
-
-

--- a/apps/backend/tests/test_fairness_evidence_profile_route.py
+++ b/apps/backend/tests/test_fairness_evidence_profile_route.py
@@ -1,0 +1,187 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.models.ai_bom import AIBOMComponent, AIBOMDocument
+from api.routes import real_ai_bom
+
+
+class StubAIBOMService:
+    def __init__(self, document):
+        self.document = document
+
+    def get_bom_document(self, document_id: str):
+        if document_id == self.document.id:
+            return self.document
+        return None
+
+
+@pytest.mark.asyncio
+async def test_fairness_evidence_profile_route_exposes_missing_evidence_as_unknown(monkeypatch):
+    document = AIBOMDocument(
+        id="bom-loan-001",
+        name="Loan Approval BOM",
+        version="1.0.0",
+        project_name="Loan Approval",
+        organization="FairMind",
+        overall_risk_level="medium",
+        overall_compliance_status="partial",
+        total_components=1,
+        components=[
+            AIBOMComponent(
+                id="loan.dataset.training",
+                name="Loan Training Dataset",
+                type="dataset",
+                version="2026.05",
+                risk_level="medium",
+                compliance_status="partial",
+            )
+        ],
+    )
+    monkeypatch.setattr(real_ai_bom, "ai_bom_service", StubAIBOMService(document))
+
+    response = await real_ai_bom.get_fairness_evidence_profile("bom-loan-001")
+    profile = response.data
+    component = profile["components"][0]
+
+    assert response.success is True
+    assert profile["bom_ref"] == "bom-loan-001"
+    assert profile["fairmind_context"]["platform_name"] == "FairMind"
+    assert profile["review_summary"]["status"] == "review_required"
+    assert component["component_id"] == "loan.dataset.training"
+    assert component["validation_state"] == "untested"
+    assert component["risk_summary"]["overall_severity"] == "unknown"
+    assert "No fairness metrics attached." in component["unknowns"]
+    assert "No bias tests attached." in component["unknowns"]
+
+
+def test_fairness_evidence_profile_endpoint_is_registered(monkeypatch):
+    document = AIBOMDocument(
+        id="bom-route-001",
+        name="Route BOM",
+        version="1.0.0",
+        project_name="Route Coverage",
+        organization="FairMind",
+        overall_risk_level="medium",
+        overall_compliance_status="partial",
+        total_components=1,
+        components=[
+            AIBOMComponent(
+                id="route.model",
+                name="Route Model",
+                type="model",
+                version="1.0.0",
+                risk_level="medium",
+                compliance_status="partial",
+            )
+        ],
+    )
+    monkeypatch.setattr(real_ai_bom, "ai_bom_service", StubAIBOMService(document))
+
+    client = TestClient(app)
+    response = client.get("/api/v1/ai-bom/documents/bom-route-001/fairness-evidence-profile")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["data"]["bom_ref"] == "bom-route-001"
+    assert payload["data"]["components"][0]["risk_summary"]["overall_severity"] == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_fairness_evidence_profile_route_preserves_component_metadata(monkeypatch):
+    document = AIBOMDocument(
+        id="bom-hiring-001",
+        name="Hiring Ranker BOM",
+        version="1.0.0",
+        project_name="Hiring Ranker",
+        organization="FairMind",
+        overall_risk_level="high",
+        overall_compliance_status="partial",
+        total_components=1,
+        risk_assessment={
+            "fairness_review_state": {
+                "status": "pending",
+                "reviewer": "internal-reviewer",
+                "pending_actions": ["Validate remediation before release approval."],
+            }
+        },
+        components=[
+            AIBOMComponent(
+                id="hiring.model.ranker",
+                name="Candidate Ranker",
+                type="model",
+                version="1.0.0",
+                risk_level="high",
+                compliance_status="partial",
+                component_metadata={
+                    "fairness_evidence": {
+                        "protected_attributes_tested": ["gender", "language"],
+                        "subgroup_coverage": {
+                            "evaluated_groups": ["gender:female", "gender:male"],
+                            "missing_groups": ["language:non_english"],
+                            "coverage_notes": "FairMind synthetic route fixture.",
+                        },
+                        "fairness_metrics": [
+                            {
+                                "metric": "top_k_selection_gap",
+                                "value": 0.16,
+                                "threshold": 0.1,
+                                "affected_groups": ["language:non_english"],
+                                "evidence_state": "simulated",
+                            }
+                        ],
+                        "bias_tests_run": [
+                            {
+                                "test_name": "Synthetic ranking fairness test",
+                                "test_type": "ranking_metric_test",
+                                "result": "language subgroup exceeds threshold",
+                                "evidence_state": "simulated",
+                                "evidence_ref": "hiring-evidence-001",
+                            }
+                        ],
+                        "evidence_refs": ["hiring-evidence-001"],
+                        "evidence_freshness": {
+                            "last_updated": "2026-05-20T00:00:00Z",
+                            "expires_at": "2026-08-20T00:00:00Z",
+                            "staleness_rule": "Evidence expires after 90 days or model update.",
+                            "evidence_state": "simulated",
+                        },
+                    },
+                    "bias_result": {
+                        "known_bias_risks": [
+                            {
+                                "risk_id": "hiring-risk-001",
+                                "description": "Language-proxy risk remains visible.",
+                                "affected_groups": ["language:non_english"],
+                                "severity": "high",
+                                "evidence_state": "simulated",
+                            }
+                        ]
+                    },
+                    "remediation_history": [
+                        {
+                            "remediation_id": "hiring-remediation-001",
+                            "description": "Feature deweighting proposed.",
+                            "status": "attempted",
+                            "validation_state": "untested",
+                            "evidence_ref": "",
+                        }
+                    ],
+                },
+            )
+        ],
+    )
+    monkeypatch.setattr(real_ai_bom, "ai_bom_service", StubAIBOMService(document))
+
+    response = await real_ai_bom.get_fairness_evidence_profile("bom-hiring-001")
+    profile = response.data
+    component = profile["components"][0]
+
+    assert response.success is True
+    assert profile["review_summary"]["status"] == "pending"
+    assert profile["review_summary"]["reviewer"] == "internal-reviewer"
+    assert component["validation_state"] == "simulated"
+    assert component["fairness_metrics"][0]["evidence_state"] == "simulated"
+    assert component["known_bias_risks"][0]["severity"] == "high"
+    assert component["risk_summary"]["overall_severity"] == "high"

--- a/apps/frontend/src/app/(dashboard)/ai-bom/page.tsx
+++ b/apps/frontend/src/app/(dashboard)/ai-bom/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useMemo } from 'react'
-import { useAIBOM, useAIBOMFairnessProfile, useAIBOMStats } from '@/lib/api/hooks/useAIBOM'
+import { useEffect, useMemo, useState } from 'react'
+import { useAIBOM, useAIBOMFairnessProfile, useAIBOMStats, type FairnessEvidenceComponent } from '@/lib/api/hooks/useAIBOM'
 import { Card } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
@@ -10,14 +10,18 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Skeleton } from '@/components/ui/skeleton'
 import { StatCard } from '@/components/charts/StatCard'
-import { Progress } from '@/components/ui/progress'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { IconFileText, IconAlertTriangle, IconCheck, IconUpload, IconRefresh, IconPackage, IconClock, IconShield } from '@tabler/icons-react'
 import { useToast } from '@/hooks/use-toast'
 
 export default function AIBOMPage() {
   const { documents, loading, error, refetch, createBOM } = useAIBOM()
-  const { stats, loading: statsLoading } = useAIBOMStats()
-  const selectedDocument = useMemo(() => documents?.[0] || null, [documents])
+  const [selectedDocumentId, setSelectedDocumentId] = useState('')
+  const selectedDocument = useMemo(() => {
+    if (!documents || documents.length === 0) return null
+    return documents.find((document) => document.id === selectedDocumentId) || documents[0]
+  }, [documents, selectedDocumentId])
+  const { stats, loading: statsLoading } = useAIBOMStats(selectedDocument?.id)
   const {
     profile: fairnessProfile,
     loading: fairnessLoading,
@@ -25,30 +29,49 @@ export default function AIBOMPage() {
     refetch: refetchFairnessProfile,
   } = useAIBOMFairnessProfile(selectedDocument?.id)
   const { toast } = useToast()
+
+  useEffect(() => {
+    if (!documents || documents.length === 0) {
+      setSelectedDocumentId('')
+      return
+    }
+
+    if (!selectedDocumentId || !documents.some((document) => document.id === selectedDocumentId)) {
+      setSelectedDocumentId(documents[0].id)
+    }
+  }, [documents, selectedDocumentId])
   
-  // Extract all components from all documents
   const components = useMemo(() => {
-    if (!documents || documents.length === 0) return []
-    return documents.flatMap(doc => doc.components || [])
-  }, [documents])
+    return selectedDocument?.components || []
+  }, [selectedDocument])
+  const vulnerableComponents = useMemo(
+    () => components.filter((component) => typeof component.vulnerabilities === 'number' && component.vulnerabilities > 0),
+    [components]
+  )
+  const unknownVulnerabilityComponents = useMemo(
+    () => components.filter((component) => typeof component.vulnerabilities !== 'number'),
+    [components]
+  )
 
   const getRiskBadge = (risk?: string) => {
     const variants: Record<string, { variant: 'default' | 'secondary' | 'destructive', label: string }> = {
+      none: { variant: 'default', label: 'None' },
       low: { variant: 'default', label: 'Low' },
       medium: { variant: 'secondary', label: 'Medium' },
       high: { variant: 'destructive', label: 'High' },
       critical: { variant: 'destructive', label: 'Critical' },
+      unknown: { variant: 'destructive', label: 'Unknown' },
     }
-    const config = variants[risk || 'low'] || variants.low
+    const config = variants[risk || 'unknown'] || variants.unknown
     return <Badge variant={config.variant} className="border-2 border-black">{config.label}</Badge>
   }
 
   const getStateBadge = (state?: string) => {
-    const normalized = state || 'unknown'
+    const normalized = state?.toLowerCase() || 'unknown'
     const variant: 'default' | 'secondary' | 'destructive' =
-      ['high', 'critical', 'missing', 'stale', 'unknown', 'untested'].includes(normalized)
+      ['high', 'critical', 'missing', 'stale', 'unknown', 'untested', 'non_compliant'].includes(normalized)
         ? 'destructive'
-        : ['medium', 'simulated', 'pending', 'review_required'].includes(normalized)
+        : ['medium', 'simulated', 'pending', 'review_required', 'partial'].includes(normalized)
           ? 'secondary'
           : 'default'
 
@@ -57,6 +80,31 @@ export default function AIBOMPage() {
         {normalized.replace(/_/g, ' ')}
       </Badge>
     )
+  }
+
+  const formatList = (items: string[] = [], fallback = 'None attached') => {
+    return items.length > 0 ? items.join(', ') : fallback
+  }
+
+  const evidenceRefsFor = (component: FairnessEvidenceComponent) => {
+    const refs = [
+      ...component.evidence_refs,
+      ...component.bias_tests_run.map((test) => test.evidence_ref).filter(Boolean),
+      ...component.remediation_history.map((remediation) => remediation.evidence_ref).filter(Boolean),
+    ]
+    return Array.from(new Set(refs))
+  }
+
+  const evidenceStatesFor = (component: FairnessEvidenceComponent) => {
+    const states = [
+      component.evidence_freshness.evidence_state,
+      ...component.fairness_metrics.map((metric) => metric.evidence_state),
+      ...component.bias_tests_run.map((test) => test.evidence_state),
+      ...component.known_bias_risks.map((risk) => risk.evidence_state),
+      ...component.regulatory_mapping.map((mapping) => mapping.evidence_state),
+      ...component.remediation_history.map((remediation) => remediation.validation_state),
+    ]
+    return Array.from(new Set(states.filter(Boolean)))
   }
 
   const handleRefresh = () => {
@@ -155,7 +203,21 @@ export default function AIBOMPage() {
             Track and manage AI model components and dependencies
           </p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          {documents.length > 0 && selectedDocument && (
+            <Select value={selectedDocument.id} onValueChange={setSelectedDocumentId}>
+              <SelectTrigger className="w-[280px] border-2 border-black bg-white font-bold">
+                <SelectValue placeholder="Select BOM" />
+              </SelectTrigger>
+              <SelectContent>
+                {documents.map((document) => (
+                  <SelectItem key={document.id} value={document.id}>
+                    {document.projectName}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
           <Button variant="default" onClick={handleRefresh}>
             <IconRefresh className="mr-2 h-4 w-4" />
             Refresh
@@ -172,17 +234,17 @@ export default function AIBOMPage() {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
           <StatCard
             title="Total Components"
-            value={stats.totalComponents || components.length}
+            value={stats.totalComponents ?? components.length}
             icon={<IconPackage className="h-5 w-5" />}
           />
           <StatCard
             title="Vulnerabilities"
-            value={stats.vulnerableComponents || components.filter(c => (c.vulnerabilities || 0) > 0).length}
+            value={stats.vulnerableComponents ?? vulnerableComponents.length}
             icon={<IconAlertTriangle className="h-5 w-5" />}
           />
           <StatCard
             title="Compliance Score"
-            value={`${stats.complianceScore || 0}%`}
+            value={typeof stats.complianceScore === 'number' ? `${stats.complianceScore}%` : 'Unknown'}
             icon={<IconShield className="h-5 w-5" />}
           />
           <StatCard
@@ -229,29 +291,35 @@ export default function AIBOMPage() {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {components.map((component) => (
-                    <TableRow key={component.id} className="border-b-2 border-black">
-                      <TableCell className="font-medium">{component.name}</TableCell>
-                      <TableCell className="font-mono text-sm">{component.version}</TableCell>
-                      <TableCell>{component.type}</TableCell>
-                      <TableCell>{getRiskBadge(component.riskLevel)}</TableCell>
-                      <TableCell>
-                        <Badge variant="default" className="border-2 border-black">
-                          {component.status || 'active'}
-                        </Badge>
-                      </TableCell>
-                      <TableCell>
-                        <span className={component.vulnerabilities && component.vulnerabilities > 0 ? 'text-red-600 font-bold' : 'text-green-600'}>
-                          {component.vulnerabilities || 0}
-                        </span>
-                      </TableCell>
-                      <TableCell>
-                        <Button variant="noShadow" size="sm">
-                          View Details
-                        </Button>
-                      </TableCell>
-                    </TableRow>
-                  ))}
+                  {components.map((component) => {
+                    const vulnerabilityCount = component.vulnerabilities
+                    const vulnerabilityClass =
+                      typeof vulnerabilityCount !== 'number'
+                        ? 'text-muted-foreground font-bold'
+                        : vulnerabilityCount > 0
+                          ? 'text-red-600 font-bold'
+                          : 'text-green-600 font-bold'
+
+                    return (
+                      <TableRow key={component.id} className="border-b-2 border-black">
+                        <TableCell className="font-medium">{component.name}</TableCell>
+                        <TableCell className="font-mono text-sm">{component.version}</TableCell>
+                        <TableCell>{component.type}</TableCell>
+                        <TableCell>{getRiskBadge(component.riskLevel)}</TableCell>
+                        <TableCell>{getStateBadge(component.status || component.complianceStatus)}</TableCell>
+                        <TableCell>
+                          <span className={vulnerabilityClass}>
+                            {typeof vulnerabilityCount === 'number' ? vulnerabilityCount : 'Unknown'}
+                          </span>
+                        </TableCell>
+                        <TableCell>
+                          <Button variant="noShadow" size="sm">
+                            View Details
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })}
                 </TableBody>
               </Table>
             )}
@@ -260,28 +328,43 @@ export default function AIBOMPage() {
 
         <TabsContent value="vulnerabilities">
           <Card className="p-6 border-2 border-black shadow-brutal">
-            {components.filter(c => (c.vulnerabilities || 0) > 0).length === 0 ? (
+            {components.length === 0 ? (
+              <div className="text-center py-12">
+                <IconPackage className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+                <p className="text-lg font-medium mb-2">No components found</p>
+                <p className="text-muted-foreground">
+                  Generate a BOM to review vulnerability metadata
+                </p>
+              </div>
+            ) : vulnerableComponents.length === 0 && unknownVulnerabilityComponents.length === 0 ? (
               <div className="text-center py-12">
                 <IconCheck className="h-12 w-12 mx-auto text-green-600 mb-4" />
                 <p className="text-lg font-medium mb-2">No vulnerabilities found</p>
                 <p className="text-muted-foreground">
-                  All components are up to date and secure
+                  Current BOM metadata reports zero known vulnerabilities
                 </p>
               </div>
             ) : (
               <div className="space-y-3">
-                {components
-                  .filter(c => (c.vulnerabilities || 0) > 0)
-                  .map((component) => (
-                    <Alert key={component.id} className="border-2 border-red-500">
-                      <IconAlertTriangle className="h-4 w-4" />
-                      <AlertTitle>{component.name} v{component.version}</AlertTitle>
-                      <AlertDescription>
-                        {component.vulnerabilities} vulnerabilities found
-                        {component.riskLevel && ` - Risk Level: ${component.riskLevel}`}
-                      </AlertDescription>
-                    </Alert>
-                  ))}
+                {vulnerableComponents.map((component) => (
+                  <Alert key={component.id} className="border-2 border-red-500">
+                    <IconAlertTriangle className="h-4 w-4" />
+                    <AlertTitle>{component.name} v{component.version}</AlertTitle>
+                    <AlertDescription>
+                      {component.vulnerabilities} vulnerabilities found
+                      {component.riskLevel && ` - Risk Level: ${component.riskLevel}`}
+                    </AlertDescription>
+                  </Alert>
+                ))}
+                {unknownVulnerabilityComponents.map((component) => (
+                  <Alert key={component.id} className="border-2 border-black">
+                    <IconAlertTriangle className="h-4 w-4" />
+                    <AlertTitle>{component.name} v{component.version}</AlertTitle>
+                    <AlertDescription>
+                      Vulnerability metadata is not attached for this component.
+                    </AlertDescription>
+                  </Alert>
+                ))}
               </div>
             )}
           </Card>
@@ -310,7 +393,11 @@ export default function AIBOMPage() {
                         {component.license || 'License not specified'}
                       </p>
                     </div>
-                    <IconCheck className="h-5 w-5 text-green-600" />
+                    {component.license ? (
+                      <IconCheck className="h-5 w-5 text-green-600" />
+                    ) : (
+                      <IconAlertTriangle className="h-5 w-5 text-red-600" />
+                    )}
                   </div>
                 ))}
               </div>
@@ -383,29 +470,174 @@ export default function AIBOMPage() {
                       <TableHead className="font-bold">Validation</TableHead>
                       <TableHead className="font-bold">Review</TableHead>
                       <TableHead className="font-bold">Unknowns</TableHead>
+                      <TableHead className="font-bold">Evidence Refs</TableHead>
                       <TableHead className="font-bold">Risk</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {fairnessProfile.components.map((component) => (
-                      <TableRow key={component.component_id} className="border-b-2 border-black">
-                        <TableCell>
-                          <p className="font-medium">{component.component_name}</p>
-                          <p className="font-mono text-xs text-muted-foreground">{component.component_id}</p>
-                        </TableCell>
-                        <TableCell className="capitalize">{component.component_type.replace(/_/g, ' ')}</TableCell>
-                        <TableCell>{getStateBadge(component.validation_state)}</TableCell>
-                        <TableCell>{getStateBadge(component.review_status)}</TableCell>
-                        <TableCell>
-                          <span className={component.unknowns.length > 0 ? 'text-red-600 font-bold' : 'text-green-600 font-bold'}>
-                            {component.unknowns.length}
-                          </span>
-                        </TableCell>
-                        <TableCell>{getStateBadge(component.risk_summary.overall_severity)}</TableCell>
-                      </TableRow>
-                    ))}
+                    {fairnessProfile.components.map((component) => {
+                      const evidenceRefs = evidenceRefsFor(component)
+
+                      return (
+                        <TableRow key={component.component_id} className="border-b-2 border-black">
+                          <TableCell>
+                            <p className="font-medium">{component.component_name}</p>
+                            <p className="font-mono text-xs text-muted-foreground">{component.component_id}</p>
+                          </TableCell>
+                          <TableCell className="capitalize">{component.component_type.replace(/_/g, ' ')}</TableCell>
+                          <TableCell>{getStateBadge(component.validation_state)}</TableCell>
+                          <TableCell>{getStateBadge(component.review_status)}</TableCell>
+                          <TableCell>
+                            <span className={component.unknowns.length > 0 ? 'text-red-600 font-bold' : 'text-green-600 font-bold'}>
+                              {component.unknowns.length}
+                            </span>
+                          </TableCell>
+                          <TableCell>
+                            <span className={evidenceRefs.length > 0 ? 'font-mono text-xs' : 'text-red-600 font-bold'}>
+                              {evidenceRefs.length > 0 ? evidenceRefs.length : 'Missing'}
+                            </span>
+                          </TableCell>
+                          <TableCell>{getStateBadge(component.risk_summary.overall_severity)}</TableCell>
+                        </TableRow>
+                      )
+                    })}
                   </TableBody>
                 </Table>
+
+                <div className="space-y-4">
+                  <div>
+                    <h2 className="text-2xl font-bold">Component Evidence Detail</h2>
+                    <p className="text-sm text-muted-foreground">
+                      Selected BOM: {selectedDocument?.projectName || fairnessProfile.system_name}
+                    </p>
+                  </div>
+
+                  {fairnessProfile.components.map((component) => {
+                    const evidenceRefs = evidenceRefsFor(component)
+                    const evidenceStates = evidenceStatesFor(component)
+
+                    return (
+                      <div key={component.component_id} className="border-2 border-black bg-white p-4">
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div>
+                            <h3 className="text-lg font-bold">{component.component_name}</h3>
+                            <p className="font-mono text-xs text-muted-foreground">{component.component_id}</p>
+                          </div>
+                          <div className="flex flex-wrap gap-2">
+                            {getStateBadge(component.validation_state)}
+                            {getStateBadge(component.review_status)}
+                            {getStateBadge(component.risk_summary.overall_severity)}
+                          </div>
+                        </div>
+
+                        <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
+                          <div>
+                            <p className="text-sm font-bold">Protected Attributes Tested</p>
+                            <p className="text-sm text-muted-foreground">
+                              {formatList(component.protected_attributes_tested)}
+                            </p>
+                          </div>
+                          <div>
+                            <p className="text-sm font-bold">Subgroup Coverage</p>
+                            <p className="text-sm text-muted-foreground">
+                              Evaluated: {formatList(component.subgroup_coverage.evaluated_groups)}
+                            </p>
+                            <p className="text-sm text-muted-foreground">
+                              Missing: {formatList(component.subgroup_coverage.missing_groups, 'None listed')}
+                            </p>
+                          </div>
+                          <div>
+                            <p className="text-sm font-bold">Evidence References</p>
+                            <p className="font-mono text-xs text-muted-foreground">
+                              {formatList(evidenceRefs)}
+                            </p>
+                          </div>
+                          <div>
+                            <p className="text-sm font-bold">Evidence States</p>
+                            <p className="text-sm text-muted-foreground">
+                              {formatList(evidenceStates)}
+                            </p>
+                          </div>
+                          <div>
+                            <p className="text-sm font-bold">Fairness Metrics</p>
+                            <p className="text-sm text-muted-foreground">
+                              {component.fairness_metrics.length > 0
+                                ? component.fairness_metrics
+                                    .map((metric) => `${metric.metric}: ${metric.value ?? 'not recorded'} (${metric.evidence_state})`)
+                                    .join(', ')
+                                : 'None attached'}
+                            </p>
+                          </div>
+                          <div>
+                            <p className="text-sm font-bold">Bias Tests</p>
+                            <p className="text-sm text-muted-foreground">
+                              {component.bias_tests_run.length > 0
+                                ? component.bias_tests_run
+                                    .map((test) => `${test.test_name}: ${test.result || 'no result'} (${test.evidence_state})`)
+                                    .join(', ')
+                                : 'None attached'}
+                            </p>
+                          </div>
+                        </div>
+
+                        <div className="mt-4 border-t-2 border-black pt-4">
+                          <p className="text-sm font-bold">Reviewer Action</p>
+                          <p className="text-sm text-muted-foreground">{component.risk_summary.reviewer_action}</p>
+                        </div>
+
+                        {component.unknowns.length > 0 && (
+                          <div className="mt-4 border-t-2 border-black pt-4">
+                            <p className="text-sm font-bold text-red-600">Unknowns</p>
+                            <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+                              {component.unknowns.map((unknown) => (
+                                <li key={unknown}>{unknown}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+
+                        {component.known_bias_risks.length > 0 && (
+                          <div className="mt-4 border-t-2 border-black pt-4">
+                            <p className="text-sm font-bold">Known Bias Risks</p>
+                            <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+                              {component.known_bias_risks.map((risk) => (
+                                <li key={risk.risk_id}>
+                                  {risk.description} Severity: {risk.severity}. Evidence: {risk.evidence_state}.
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+
+                        {component.remediation_history.length > 0 && (
+                          <div className="mt-4 border-t-2 border-black pt-4">
+                            <p className="text-sm font-bold">Remediation Validation</p>
+                            <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+                              {component.remediation_history.map((remediation) => (
+                                <li key={remediation.remediation_id}>
+                                  {remediation.description} Status: {remediation.status}. Validation: {remediation.validation_state}.
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+
+                        {component.regulatory_mapping.length > 0 && (
+                          <div className="mt-4 border-t-2 border-black pt-4">
+                            <p className="text-sm font-bold">Regulatory Claims</p>
+                            <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+                              {component.regulatory_mapping.map((mapping) => (
+                                <li key={`${mapping.framework}-${mapping.control}-${mapping.claim}`}>
+                                  {mapping.framework} {mapping.control}: {mapping.claim}. Evidence: {mapping.evidence_state}.
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+                      </div>
+                    )
+                  })}
+                </div>
               </div>
             ) : (
               <div className="text-center py-12">

--- a/apps/frontend/src/app/(dashboard)/ai-bom/page.tsx
+++ b/apps/frontend/src/app/(dashboard)/ai-bom/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState, useMemo } from 'react'
-import { useAIBOM, useAIBOMStats } from '@/lib/api/hooks/useAIBOM'
+import { useMemo } from 'react'
+import { useAIBOM, useAIBOMFairnessProfile, useAIBOMStats } from '@/lib/api/hooks/useAIBOM'
 import { Card } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
@@ -17,6 +17,13 @@ import { useToast } from '@/hooks/use-toast'
 export default function AIBOMPage() {
   const { documents, loading, error, refetch, createBOM } = useAIBOM()
   const { stats, loading: statsLoading } = useAIBOMStats()
+  const selectedDocument = useMemo(() => documents?.[0] || null, [documents])
+  const {
+    profile: fairnessProfile,
+    loading: fairnessLoading,
+    error: fairnessError,
+    refetch: refetchFairnessProfile,
+  } = useAIBOMFairnessProfile(selectedDocument?.id)
   const { toast } = useToast()
   
   // Extract all components from all documents
@@ -36,11 +43,62 @@ export default function AIBOMPage() {
     return <Badge variant={config.variant} className="border-2 border-black">{config.label}</Badge>
   }
 
+  const getStateBadge = (state?: string) => {
+    const normalized = state || 'unknown'
+    const variant: 'default' | 'secondary' | 'destructive' =
+      ['high', 'critical', 'missing', 'stale', 'unknown', 'untested'].includes(normalized)
+        ? 'destructive'
+        : ['medium', 'simulated', 'pending', 'review_required'].includes(normalized)
+          ? 'secondary'
+          : 'default'
+
+    return (
+      <Badge variant={variant} className="border-2 border-black capitalize">
+        {normalized.replace(/_/g, ' ')}
+      </Badge>
+    )
+  }
+
+  const handleRefresh = () => {
+    refetch()
+    refetchFairnessProfile()
+  }
+
   const handleGenerateBOM = async () => {
     try {
       await createBOM({
-        projectName: 'Default Project',
+        name: 'Default Project BOM',
+        version: '1.0.0',
         description: 'Auto-generated BOM',
+        project_name: 'Default Project',
+        organization: 'FairMind',
+        overall_risk_level: 'medium',
+        overall_compliance_status: 'partial',
+        components: [
+          {
+            id: 'default.dataset',
+            name: 'Default Dataset',
+            type: 'dataset',
+            version: 'unknown',
+            risk_level: 'medium',
+            compliance_status: 'partial',
+            component_metadata: {
+              profile_component_type: 'dataset',
+            },
+          },
+          {
+            id: 'default.model',
+            name: 'Default Model',
+            type: 'model',
+            version: 'unknown',
+            risk_level: 'medium',
+            compliance_status: 'partial',
+            dependencies: ['default.dataset'],
+            component_metadata: {
+              profile_component_type: 'model',
+            },
+          },
+        ],
       })
       toast({
         title: "BOM Generated",
@@ -98,7 +156,7 @@ export default function AIBOMPage() {
           </p>
         </div>
         <div className="flex gap-2">
-          <Button variant="default" onClick={() => refetch()}>
+          <Button variant="default" onClick={handleRefresh}>
             <IconRefresh className="mr-2 h-4 w-4" />
             Refresh
           </Button>
@@ -139,7 +197,8 @@ export default function AIBOMPage() {
         <TabsList className="border-2 border-black">
           <TabsTrigger value="components" className="border-r-2 border-black">Components</TabsTrigger>
           <TabsTrigger value="vulnerabilities" className="border-r-2 border-black">Vulnerabilities</TabsTrigger>
-          <TabsTrigger value="licenses">Licenses</TabsTrigger>
+          <TabsTrigger value="licenses" className="border-r-2 border-black">Licenses</TabsTrigger>
+          <TabsTrigger value="fairness-evidence">Fairness Evidence</TabsTrigger>
         </TabsList>
 
         <TabsContent value="components">
@@ -258,8 +317,108 @@ export default function AIBOMPage() {
             )}
           </Card>
         </TabsContent>
+
+        <TabsContent value="fairness-evidence">
+          <Card className="p-6 border-2 border-black shadow-brutal">
+            {!selectedDocument ? (
+              <div className="text-center py-12">
+                <IconShield className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+                <p className="text-lg font-medium mb-2">No BOM selected</p>
+                <p className="text-muted-foreground">
+                  Generate a BOM to review fairness evidence state
+                </p>
+              </div>
+            ) : fairnessLoading ? (
+              <div className="space-y-4">
+                <Skeleton className="h-24 w-full" />
+                <Skeleton className="h-64 w-full" />
+              </div>
+            ) : fairnessError ? (
+              <Alert className="border-2 border-red-500">
+                <IconAlertTriangle className="h-4 w-4" />
+                <AlertTitle>Fairness Evidence Unavailable</AlertTitle>
+                <AlertDescription>
+                  {fairnessError.message}
+                  <br />
+                  <Button variant="default" className="mt-4" onClick={() => refetchFairnessProfile()}>
+                    <IconRefresh className="mr-2 h-4 w-4" />
+                    Retry
+                  </Button>
+                </AlertDescription>
+              </Alert>
+            ) : fairnessProfile ? (
+              <div className="space-y-6">
+                <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+                  <div className="border-2 border-black p-4 bg-white">
+                    <p className="text-sm font-medium text-muted-foreground">Overall Severity</p>
+                    <div className="mt-2">{getStateBadge(fairnessProfile.risk_summary.overall_severity)}</div>
+                  </div>
+                  <div className="border-2 border-black p-4 bg-white">
+                    <p className="text-sm font-medium text-muted-foreground">Unknowns</p>
+                    <p className="text-2xl font-bold mt-1">{fairnessProfile.risk_summary.unknown_count}</p>
+                  </div>
+                  <div className="border-2 border-black p-4 bg-white">
+                    <p className="text-sm font-medium text-muted-foreground">Simulated Evidence</p>
+                    <p className="text-2xl font-bold mt-1">{fairnessProfile.risk_summary.simulated_evidence_count}</p>
+                  </div>
+                  <div className="border-2 border-black p-4 bg-white">
+                    <p className="text-sm font-medium text-muted-foreground">Review Status</p>
+                    <div className="mt-2">{getStateBadge(fairnessProfile.review_summary.status)}</div>
+                  </div>
+                </div>
+
+                <Alert className="border-2 border-black">
+                  <IconShield className="h-4 w-4" />
+                  <AlertTitle>{fairnessProfile.system_name}</AlertTitle>
+                  <AlertDescription>
+                    {fairnessProfile.risk_summary.reviewer_action}
+                  </AlertDescription>
+                </Alert>
+
+                <Table>
+                  <TableHeader>
+                    <TableRow className="border-2 border-black">
+                      <TableHead className="font-bold">Component</TableHead>
+                      <TableHead className="font-bold">Type</TableHead>
+                      <TableHead className="font-bold">Validation</TableHead>
+                      <TableHead className="font-bold">Review</TableHead>
+                      <TableHead className="font-bold">Unknowns</TableHead>
+                      <TableHead className="font-bold">Risk</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {fairnessProfile.components.map((component) => (
+                      <TableRow key={component.component_id} className="border-b-2 border-black">
+                        <TableCell>
+                          <p className="font-medium">{component.component_name}</p>
+                          <p className="font-mono text-xs text-muted-foreground">{component.component_id}</p>
+                        </TableCell>
+                        <TableCell className="capitalize">{component.component_type.replace(/_/g, ' ')}</TableCell>
+                        <TableCell>{getStateBadge(component.validation_state)}</TableCell>
+                        <TableCell>{getStateBadge(component.review_status)}</TableCell>
+                        <TableCell>
+                          <span className={component.unknowns.length > 0 ? 'text-red-600 font-bold' : 'text-green-600 font-bold'}>
+                            {component.unknowns.length}
+                          </span>
+                        </TableCell>
+                        <TableCell>{getStateBadge(component.risk_summary.overall_severity)}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            ) : (
+              <div className="text-center py-12">
+                <IconShield className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+                <p className="text-lg font-medium mb-2">No fairness evidence profile</p>
+                <p className="text-muted-foreground">
+                  Refresh this BOM to load current fairness evidence state
+                </p>
+              </div>
+            )}
+          </Card>
+        </TabsContent>
       </Tabs>
     </div>
   )
 }
-

--- a/apps/frontend/src/lib/api/endpoints.ts
+++ b/apps/frontend/src/lib/api/endpoints.ts
@@ -168,6 +168,7 @@ export const API_ENDPOINTS = {
     create: '/api/v1/ai-bom/create',
     document: (bomId: string) => `/api/v1/ai-bom/documents/${bomId}`,
     analyze: (bomId: string) => `/api/v1/ai-bom/documents/${bomId}/analyze`,
+    fairnessEvidenceProfile: (bomId: string) => `/api/v1/ai-bom/documents/${bomId}/fairness-evidence-profile`,
     metrics: (bomId: string) => `/api/v1/ai-bom/documents/${bomId}/metrics`,
     dependencyGraph: (bomId: string) => `/api/v1/ai-bom/documents/${bomId}/dependency-graph`,
     componentTypes: '/api/v1/ai-bom/components/types',

--- a/apps/frontend/src/lib/api/hooks/index.ts
+++ b/apps/frontend/src/lib/api/hooks/index.ts
@@ -21,7 +21,6 @@ export { useAuditLogs } from './useAuditLogs'
 export { useMonitoring, useSystemHealth } from './useMonitoring'
 export { useAnalytics } from './useAnalytics'
 export { useCompliance } from './useCompliance'
-export { useAIBOM, useAIBOMStats } from './useAIBOM'
+export { useAIBOM, useAIBOMFairnessProfile, useAIBOMStats } from './useAIBOM'
 export { useModernBias } from './useModernBias'
 export { useMultimodalBias } from './useMultimodalBias'
-

--- a/apps/frontend/src/lib/api/hooks/useAIBOM.ts
+++ b/apps/frontend/src/lib/api/hooks/useAIBOM.ts
@@ -6,20 +6,27 @@ import { useState, useEffect, useCallback } from 'react'
 import { apiClient, type ApiResponse } from '../api-client'
 import { API_ENDPOINTS } from '../endpoints'
 
+type RawObject = Record<string, unknown>
+export type AIBOMRiskLevel = 'none' | 'low' | 'medium' | 'high' | 'critical' | 'unknown'
+
 export interface BOMComponent {
   id: string
   name: string
   version: string
-  type: 'model' | 'dataset' | 'library' | 'framework' | 'tool'
+  type: string
   vendor?: string
   license?: string
   status?: 'active' | 'deprecated' | 'vulnerable' | 'updated'
-  riskLevel?: 'low' | 'medium' | 'high' | 'critical'
+  riskLevel: AIBOMRiskLevel
+  complianceStatus?: string
   lastUpdated?: string
   dependencies?: string[]
   vulnerabilities?: number
   compliance?: string
   description?: string
+  componentMetadata?: RawObject
+  createdAt?: string
+  updatedAt?: string
 }
 
 export interface BOMStats {
@@ -33,12 +40,18 @@ export interface BOMStats {
 
 export interface BOMDocument {
   id: string
+  name?: string
+  version?: string
+  description?: string
   projectName: string
+  organization?: string
   components: BOMComponent[]
-  createdAt: string
-  updatedAt: string
-  riskLevel?: string
+  createdAt?: string
+  updatedAt?: string
+  riskLevel: AIBOMRiskLevel
   complianceStatus?: string
+  totalComponents?: number
+  tags?: string[]
 }
 
 export interface FairnessEvidenceProfile {
@@ -72,9 +85,16 @@ export interface FairnessEvidenceComponent {
   component_type: string
   component_name: string
   version: string
+  upstream_components: string[]
+  downstream_components: string[]
   validation_state: string
   review_status: string
   protected_attributes_tested: string[]
+  subgroup_coverage: {
+    evaluated_groups: string[]
+    missing_groups: string[]
+    coverage_notes: string
+  }
   fairness_metrics: Array<{
     metric: string
     value?: number | string | null
@@ -96,6 +116,26 @@ export interface FairnessEvidenceComponent {
     severity: string
     evidence_state: string
   }>
+  remediation_history: Array<{
+    remediation_id: string
+    description: string
+    status: string
+    validation_state: string
+    evidence_ref: string
+  }>
+  evidence_refs: string[]
+  evidence_freshness: {
+    last_updated?: string | null
+    expires_at?: string | null
+    staleness_rule: string
+    evidence_state: string
+  }
+  regulatory_mapping: Array<{
+    framework: string
+    control: string
+    claim: string
+    evidence_state: string
+  }>
   unknowns: string[]
   risk_summary: {
     overall_severity: string
@@ -104,6 +144,127 @@ export interface FairnessEvidenceComponent {
     stale_evidence_count: number
     simulated_evidence_count: number
     reviewer_action: string
+  }
+}
+
+const isRecord = (value: unknown): value is RawObject =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const asString = (value: unknown, fallback = ''): string => {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  return fallback
+}
+
+const asOptionalString = (value: unknown): string | undefined => {
+  const text = asString(value)
+  return text || undefined
+}
+
+const asOptionalNumber = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : undefined
+  }
+  return undefined
+}
+
+const asStringArray = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((item) => asString(item))
+    .filter((item) => item.length > 0)
+}
+
+const asObject = (value: unknown): RawObject | undefined =>
+  isRecord(value) ? value : undefined
+
+const normalizeRiskLevel = (value: unknown): AIBOMRiskLevel => {
+  const normalized = asString(value).toLowerCase()
+  if (['none', 'low', 'medium', 'high', 'critical'].includes(normalized)) {
+    return normalized as AIBOMRiskLevel
+  }
+  return 'unknown'
+}
+
+const normalizeComponentStatus = (value: unknown): BOMComponent['status'] | undefined => {
+  const normalized = asString(value).toLowerCase()
+  if (['active', 'deprecated', 'vulnerable', 'updated'].includes(normalized)) {
+    return normalized as BOMComponent['status']
+  }
+  return undefined
+}
+
+const normalizeBOMComponent = (component: unknown, index: number): BOMComponent => {
+  const raw = isRecord(component) ? component : {}
+  const fallbackId = `component-${index + 1}`
+  const name = asString(raw.name, fallbackId)
+  const componentMetadata = asObject(raw.componentMetadata) || asObject(raw.component_metadata)
+
+  return {
+    id: asString(raw.id, fallbackId),
+    name,
+    version: asString(raw.version, 'unknown'),
+    type: asString(raw.type, 'unknown'),
+    vendor: asOptionalString(raw.vendor),
+    license: asOptionalString(raw.license),
+    status: normalizeComponentStatus(raw.status),
+    riskLevel: normalizeRiskLevel(raw.riskLevel ?? raw.risk_level),
+    complianceStatus: asOptionalString(raw.complianceStatus ?? raw.compliance_status),
+    lastUpdated: asOptionalString(raw.lastUpdated ?? raw.last_updated ?? raw.updated_at),
+    dependencies: asStringArray(raw.dependencies),
+    vulnerabilities: asOptionalNumber(raw.vulnerabilities),
+    compliance: asOptionalString(raw.compliance ?? raw.compliance_status),
+    description: asOptionalString(raw.description),
+    componentMetadata,
+    createdAt: asOptionalString(raw.createdAt ?? raw.created_at),
+    updatedAt: asOptionalString(raw.updatedAt ?? raw.updated_at),
+  }
+}
+
+const normalizeBOMDocument = (document: unknown, index: number): BOMDocument => {
+  const raw = isRecord(document) ? document : {}
+  const components = Array.isArray(raw.components)
+    ? raw.components.map((component, componentIndex) => normalizeBOMComponent(component, componentIndex))
+    : []
+  const fallbackId = `bom-${index + 1}`
+  const name = asOptionalString(raw.name)
+
+  return {
+    id: asString(raw.id, fallbackId),
+    name,
+    version: asOptionalString(raw.version),
+    description: asOptionalString(raw.description),
+    projectName: asString(raw.projectName ?? raw.project_name ?? raw.name, fallbackId),
+    organization: asOptionalString(raw.organization),
+    components,
+    createdAt: asOptionalString(raw.createdAt ?? raw.created_at),
+    updatedAt: asOptionalString(raw.updatedAt ?? raw.updated_at),
+    riskLevel: normalizeRiskLevel(raw.riskLevel ?? raw.overall_risk_level),
+    complianceStatus: asOptionalString(raw.complianceStatus ?? raw.overall_compliance_status),
+    totalComponents: asOptionalNumber(raw.totalComponents ?? raw.total_components) ?? components.length,
+    tags: asStringArray(raw.tags),
+  }
+}
+
+const extractBOMDocuments = (payload: unknown): BOMDocument[] => {
+  if (!isRecord(payload)) return []
+  const documents = payload.documents ?? payload.data
+  if (!Array.isArray(documents)) return []
+  return documents.map((document, index) => normalizeBOMDocument(document, index))
+}
+
+const normalizeBOMStats = (stats: unknown): BOMStats => {
+  const raw = isRecord(stats) ? stats : {}
+
+  return {
+    totalComponents: asOptionalNumber(raw.totalComponents ?? raw.total_components),
+    vulnerableComponents: asOptionalNumber(raw.vulnerableComponents ?? raw.vulnerable_components),
+    outdatedComponents: asOptionalNumber(raw.outdatedComponents ?? raw.outdated_components),
+    complianceScore: asOptionalNumber(raw.complianceScore ?? raw.compliance_score),
+    licenseIssues: asOptionalNumber(raw.licenseIssues ?? raw.license_issues),
+    lastScan: asOptionalString(raw.lastScan ?? raw.last_scan),
   }
 }
 
@@ -117,7 +278,7 @@ export function useAIBOM() {
       setLoading(true)
       setError(null)
       
-      const response: ApiResponse<{ documents?: BOMDocument[], data?: BOMDocument[] }> = await apiClient.get(
+      const response: ApiResponse<unknown> = await apiClient.get(
         API_ENDPOINTS.aiBOM.documents,
         {
           enableRetry: true,
@@ -127,8 +288,7 @@ export function useAIBOM() {
       )
       
       if (response.success && response.data) {
-        const data = response.data as any
-        setDocuments(data.documents || data.data || [])
+        setDocuments(extractBOMDocuments(response.data))
         setError(null)
       } else {
         const errorMessage = response.error || 'Failed to fetch AI BOM documents'
@@ -156,7 +316,7 @@ export function useAIBOM() {
   const createBOM = async (request: any) => {
     try {
       setLoading(true)
-      const response: ApiResponse<BOMDocument> = await apiClient.post(
+      const response: ApiResponse<unknown> = await apiClient.post(
         API_ENDPOINTS.aiBOM.create,
         request,
         {
@@ -167,7 +327,7 @@ export function useAIBOM() {
       
       if (response.success && response.data) {
         await fetchDocuments() // Refresh list
-        return response.data
+        return normalizeBOMDocument(response.data, 0)
       } else {
         throw new Error(response.error || 'Failed to create AI BOM')
       }
@@ -251,7 +411,7 @@ export function useAIBOMStats(documentId?: string) {
         ? API_ENDPOINTS.aiBOM.metrics(documentId)
         : API_ENDPOINTS.aiBOM.stats
       
-      const response: ApiResponse<BOMStats> = await apiClient.get(
+      const response: ApiResponse<unknown> = await apiClient.get(
         endpoint,
         {
           enableRetry: true,
@@ -261,7 +421,7 @@ export function useAIBOMStats(documentId?: string) {
       )
       
       if (response.success && response.data) {
-        setStats(response.data)
+        setStats(normalizeBOMStats(response.data))
         setError(null)
       } else {
         const errorMessage = response.error || 'Failed to fetch AI BOM stats'

--- a/apps/frontend/src/lib/api/hooks/useAIBOM.ts
+++ b/apps/frontend/src/lib/api/hooks/useAIBOM.ts
@@ -41,6 +41,72 @@ export interface BOMDocument {
   complianceStatus?: string
 }
 
+export interface FairnessEvidenceProfile {
+  profile_id: string
+  profile_version: string
+  bom_ref: string
+  system_name: string
+  system_domain: string
+  generated_at: string
+  components: FairnessEvidenceComponent[]
+  risk_summary: {
+    overall_severity: string
+    key_risks: string[]
+    unknown_count: number
+    stale_evidence_count: number
+    simulated_evidence_count: number
+    reviewer_action: string
+  }
+  review_summary: {
+    status: string
+    reviewer?: string | null
+    reviewed_at?: string | null
+    notes: string
+    pending_actions: string[]
+  }
+  limitations: string[]
+}
+
+export interface FairnessEvidenceComponent {
+  component_id: string
+  component_type: string
+  component_name: string
+  version: string
+  validation_state: string
+  review_status: string
+  protected_attributes_tested: string[]
+  fairness_metrics: Array<{
+    metric: string
+    value?: number | string | null
+    threshold?: number | string | null
+    affected_groups: string[]
+    evidence_state: string
+  }>
+  bias_tests_run: Array<{
+    test_name: string
+    test_type: string
+    result: string
+    evidence_state: string
+    evidence_ref: string
+  }>
+  known_bias_risks: Array<{
+    risk_id: string
+    description: string
+    affected_groups: string[]
+    severity: string
+    evidence_state: string
+  }>
+  unknowns: string[]
+  risk_summary: {
+    overall_severity: string
+    key_risks: string[]
+    unknown_count: number
+    stale_evidence_count: number
+    simulated_evidence_count: number
+    reviewer_action: string
+  }
+}
+
 export function useAIBOM() {
   const [documents, setDocuments] = useState<BOMDocument[]>([])
   const [loading, setLoading] = useState(true)
@@ -116,6 +182,61 @@ export function useAIBOM() {
   return { documents, loading, error, refetch: fetchDocuments, createBOM }
 }
 
+export function useAIBOMFairnessProfile(documentId?: string) {
+  const [profile, setProfile] = useState<FairnessEvidenceProfile | null>(null)
+  const [loading, setLoading] = useState(Boolean(documentId))
+  const [error, setError] = useState<Error | null>(null)
+
+  const fetchProfile = useCallback(async () => {
+    if (!documentId) {
+      setProfile(null)
+      setError(null)
+      setLoading(false)
+      return
+    }
+
+    try {
+      setLoading(true)
+      setError(null)
+
+      const response: ApiResponse<FairnessEvidenceProfile> = await apiClient.get(
+        API_ENDPOINTS.aiBOM.fairnessEvidenceProfile(documentId),
+        {
+          enableRetry: true,
+          maxRetries: 2,
+          timeout: 10000,
+        }
+      )
+
+      if (response.success && response.data) {
+        setProfile(response.data)
+        setError(null)
+      } else {
+        const errorMessage = response.error || 'Failed to fetch fairness evidence profile'
+        setError(new Error(errorMessage))
+        setProfile(null)
+      }
+    } catch (err) {
+      console.error('AI BOM fairness evidence profile API error:', err)
+      setError(err instanceof Error ? err : new Error('Failed to fetch fairness evidence profile'))
+      setProfile(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [documentId])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      setLoading(false)
+      return
+    }
+
+    fetchProfile()
+  }, [fetchProfile])
+
+  return { profile, loading, error, refetch: fetchProfile }
+}
+
 export function useAIBOMStats(documentId?: string) {
   const [stats, setStats] = useState<BOMStats | null>(null)
   const [loading, setLoading] = useState(true)
@@ -167,4 +288,3 @@ export function useAIBOMStats(documentId?: string) {
 
   return { stats, loading, error, refetch: fetchStats }
 }
-


### PR DESCRIPTION
## Summary
- Adds an AI-BOM fairness evidence profile endpoint that adapts existing FairMind AIBOM documents into the merged profile generator.
- Preserves missing fairness evidence as explicit unknown risk instead of treating it as low risk.
- Adds a Fairness Evidence tab to the AI-BOM dashboard and fixes the generate-BOM payload so a default BOM can produce a reviewable profile.

## Test Plan
- `uv run pytest tests/test_fairness_evidence_profile_service.py tests/test_fairness_evidence_profile_route.py -q`
- `NEXT_PUBLIC_API_URL=http://localhost:8000 npm run build`
- `tooling/check_no_archive_imports.sh`
- `git diff --check`
- `rg -n "BiasBOM|biasbom|Bias BOM|BIASBOM" research/aibom-fairness-evidence apps/backend/src/api/routers/real_ai_bom.py apps/backend/tests/test_fairness_evidence_profile_route.py apps/frontend/src/lib/api/hooks/useAIBOM.ts apps/frontend/src/lib/api/endpoints.ts apps/frontend/src/app/\(dashboard\)/ai-bom/page.tsx`

## Notes
- `tooling/check_backend_layer_boundaries.sh` still reports pre-existing API imports in other routers; this change does not add a domain or infrastructure API import violation.
- The profile remains evidence-review tooling, not proof of fairness or production validation.
