### PR TITLE
feat(assurance): bind evidence to evaluator registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -307,6 +307,10 @@ temp/
 localhost.har
 *.har
 apps/backend/public_key.pem
+
+# The broad ML artifact rule ``models/`` must not hide active API source.
+!apps/backend/api/models/
+!apps/backend/api/models/**/*.py
 apps/backend/private_key.pem
 apps/backend/api/services/real_bias_detection_service.py
 apps/backend/email_service.py

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ The current branch is an **internal, default-off trust-foundation alpha**. It im
 |---|---|---|
 | Target and suite identity | Implemented in the v2 contract | Immutable planning metadata |
 | Execution envelope and Passport v2 binding | Implemented and tested | Evidence-integrity foundation |
-| Signature, replay, scope, and admission checks | Implemented as a default-off kernel | Supporting evidence verification |
-| Public admission API and reviewer workflow | Not yet shipped | Do not claim |
+| Signature, replay, scope, and admission checks | Implemented as a default-off kernel with a separately gated route boundary | Supporting evidence verification |
+| Public admission API and reviewer workflow | Route boundary is composed but disabled; reviewer workflow is not shipped | Do not claim |
 | Sandboxed worker execution | Not yet shipped | Do not claim |
 | LLM, agent, code, vision, image, audio, video, and multimodal packs | Not yet independently validated | Planned/experimental only |
 | Pre-deployment, realtime, and post-deployment assurance | Not yet shipped | Do not claim |
@@ -92,7 +92,7 @@ Hosted links, where available, are development or demonstration surfaces and are
 
 **Implemented foundation**: target and suite identity, execution-envelope binding, Passport v2 verification primitives, trust-policy checks, replay protection, and evidence-state contracts.
 
-**In progress**: public evidence admission, evaluator registry, four-eyes review, frontend evidence states, worker isolation, and release-gate verification.
+**In progress**: enabling public evidence admission after evaluator registration, four-eyes review, frontend evidence states, worker isolation, and release-gate verification. The route remains disabled by default and its bootstrap catalog contains no admitted evaluators.
 
 **Planned after the foundation**: real predictive, LLM, agent, code, vision, image, audio, video, and multimodal evaluation packs; pre-deployment and realtime pre/post workflows; and independently benchmarked execution claims.
 

--- a/apps/backend/api/composition/verified_evidence_admission.py
+++ b/apps/backend/api/composition/verified_evidence_admission.py
@@ -1,0 +1,41 @@
+"""Composition root for the gated verified Evidence Passport V2 route.
+
+The route is deliberately backed by an empty server-owned evaluator catalog
+until evaluator registration persistence and approval ceremonies are released.
+That makes an accidentally enabled flag fail closed as an unregistered
+evaluator instead of allowing submitted metadata to authorize itself.
+"""
+
+from sqlalchemy.orm import Session
+
+from src.application.services.evidence_authenticity_service import (
+    EvidenceAuthenticityService,
+)
+from src.application.services.evaluator_registry import StaticEvaluatorRegistry
+from src.application.services.verified_evidence_admission_service import (
+    VerifiedEvidenceAdmissionService,
+)
+from src.infrastructure.db.repositories.evaluation_workbench_repository import (
+    SqlAlchemyEvaluationWorkbenchUnitOfWork,
+)
+from src.infrastructure.security import Ed25519EvidenceVerifier
+
+
+def build_verified_evidence_admission_service(
+    session: Session,
+) -> VerifiedEvidenceAdmissionService:
+    """Build a server-owned admission service without caller-controlled trust.
+
+    The static catalog has no registrations by design. It is a safe bootstrap
+    composition for the independently gated route; persistent registration and
+    key ceremonies must be completed before any evaluator is admitted.
+    """
+
+    return VerifiedEvidenceAdmissionService(
+        SqlAlchemyEvaluationWorkbenchUnitOfWork(session),
+        EvidenceAuthenticityService(Ed25519EvidenceVerifier()),
+        StaticEvaluatorRegistry(catalog_version="bootstrap-0", registrations=()),
+    )
+
+
+__all__ = ["build_verified_evidence_admission_service"]

--- a/apps/backend/api/main.py
+++ b/apps/backend/api/main.py
@@ -400,6 +400,16 @@ if settings.assurance_v2_enabled:
         tags=["evaluation-workbench-v2"],
         required=True,
     )
+    if settings.assurance_v2_evidence_submit_enabled:
+        _include_router(
+            "api.routes.evaluation_workbench",
+            prefix="/api/v1/ai-governance",
+            tags=["evaluation-workbench-v2-evidence"],
+            attr="verified_evidence_router",
+            required=True,
+        )
+    else:
+        logger.info("Verified Evidence Passport admission route is disabled")
 else:
     logger.info("Assurance-contract v2 routes are disabled")
 _include_router("api.routes.environmental", tags=["environmental"], required=False)

--- a/apps/backend/api/models/__init__.py
+++ b/apps/backend/api/models/__init__.py
@@ -1,0 +1,1 @@
+"""Compatibility request and response models for active API routes."""

--- a/apps/backend/api/models/ai_bom.py
+++ b/apps/backend/api/models/ai_bom.py
@@ -1,0 +1,121 @@
+"""AI BOM API compatibility models.
+
+The active AI BOM router and service still use the historical ``api.models``
+import path.  Keep these transport models at that boundary rather than
+reintroducing an archive dependency or coupling the router to ORM entities.
+"""
+
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ComponentType(str, Enum):
+    MODEL = "model"
+    DATASET = "dataset"
+    LIBRARY = "library"
+    FRAMEWORK = "framework"
+    DEPENDENCY = "dependency"
+
+
+class RiskLevel(str, Enum):
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    NONE = "none"
+
+
+class ComplianceStatus(str, Enum):
+    COMPLIANT = "compliant"
+    NON_COMPLIANT = "non_compliant"
+    PARTIAL = "partial"
+    NOT_APPLICABLE = "not_applicable"
+
+
+class AIBOMComponent(BaseModel):
+    id: str | None = None
+    name: str
+    type: str
+    version: str
+    description: str | None = None
+    vendor: str | None = None
+    license: str | None = None
+    risk_level: str
+    compliance_status: str
+    dependencies: list[str] = Field(default_factory=list)
+    component_metadata: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class AIBOMAnalysis(BaseModel):
+    id: str | None = None
+    analysis_type: str
+    risk_score: float
+    compliance_score: float
+    security_score: float
+    performance_score: float
+    cost_analysis: dict[str, Any] = Field(default_factory=dict)
+    recommendations: list[str] = Field(default_factory=list)
+    created_at: datetime | None = None
+
+
+class AIBOMDocument(BaseModel):
+    id: str | None = None
+    name: str
+    version: str
+    description: str | None = None
+    project_name: str
+    organization: str | None = None
+    overall_risk_level: str
+    overall_compliance_status: str
+    total_components: int = 0
+    created_by: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    tags: list[str] = Field(default_factory=list)
+    risk_assessment: dict[str, Any] = Field(default_factory=dict)
+    compliance_report: dict[str, Any] = Field(default_factory=dict)
+    recommendations: list[str] = Field(default_factory=list)
+    data_layer: dict[str, Any] = Field(default_factory=dict)
+    model_development_layer: dict[str, Any] = Field(default_factory=dict)
+    infrastructure_layer: dict[str, Any] = Field(default_factory=dict)
+    deployment_layer: dict[str, Any] = Field(default_factory=dict)
+    monitoring_layer: dict[str, Any] = Field(default_factory=dict)
+    security_layer: dict[str, Any] = Field(default_factory=dict)
+    compliance_layer: dict[str, Any] = Field(default_factory=dict)
+    components: list[AIBOMComponent] = Field(default_factory=list)
+    analyses: list[AIBOMAnalysis] = Field(default_factory=list)
+
+
+class AIBOMRequest(BaseModel):
+    name: str
+    version: str
+    description: str | None = None
+    project_name: str
+    organization: str | None = None
+    overall_risk_level: str
+    overall_compliance_status: str
+    created_by: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    risk_assessment: dict[str, Any] = Field(default_factory=dict)
+    compliance_report: dict[str, Any] = Field(default_factory=dict)
+    recommendations: list[str] = Field(default_factory=list)
+    data_layer: dict[str, Any] = Field(default_factory=dict)
+    model_development_layer: dict[str, Any] = Field(default_factory=dict)
+    infrastructure_layer: dict[str, Any] = Field(default_factory=dict)
+    deployment_layer: dict[str, Any] = Field(default_factory=dict)
+    monitoring_layer: dict[str, Any] = Field(default_factory=dict)
+    security_layer: dict[str, Any] = Field(default_factory=dict)
+    compliance_layer: dict[str, Any] = Field(default_factory=dict)
+    components: list[AIBOMComponent] = Field(default_factory=list)
+
+
+class AIBOMResponse(BaseModel):
+    success: bool
+    data: Any
+    message: str
+    timestamp: datetime = Field(default_factory=datetime.now)

--- a/apps/backend/config/settings.py
+++ b/apps/backend/config/settings.py
@@ -48,6 +48,9 @@ class Settings(BaseSettings):
     database_max_overflow: int = 30
     database_timeout: int = 30
     assurance_v2_enabled: bool = False
+    # Verified Evidence Passport admission remains independently disabled until
+    # the route, trust catalog, and reviewer workflow pass their release gate.
+    assurance_v2_evidence_submit_enabled: bool = False
     assurance_migration_schema: Optional[str] = None
     
     # Neon Auth + Data API

--- a/apps/backend/src/api/middleware/audit_logging.py
+++ b/apps/backend/src/api/middleware/audit_logging.py
@@ -17,12 +17,7 @@ from functools import wraps
 import hashlib
 
 from fastapi import Request
-from sqlalchemy import Column, String, DateTime, JSON, Text, Index
-from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.sql import func
-import uuid
-
-from database.connection import Base
+from database.models import AuditLog
 from config.settings import settings
 
 logger = logging.getLogger("fairmind.audit")
@@ -30,6 +25,7 @@ logger = logging.getLogger("fairmind.audit")
 
 class AuditEventType(str, Enum):
     """Types of audit events"""
+
     COMPLIANCE_CHECK = "compliance_check"
     EVIDENCE_ACCESS = "evidence_access"
     EVIDENCE_MODIFICATION = "evidence_modification"
@@ -44,50 +40,21 @@ class AuditEventType(str, Enum):
 
 class AuditSeverity(str, Enum):
     """Severity levels for audit events"""
+
     INFO = "info"
     WARNING = "warning"
     CRITICAL = "critical"
 
 
-# ============================================================================
-# Audit Log Model
-# ============================================================================
-
-class AuditLog(Base):
-    """Model for audit logging"""
-    __tablename__ = "audit_logs"
-
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
-    event_type = Column(String(100), nullable=False, index=True)
-    severity = Column(String(50), nullable=False, index=True)
-    user_id = Column(String(255), nullable=True, index=True)
-    resource_type = Column(String(100), nullable=False, index=True)
-    resource_id = Column(String(255), nullable=True, index=True)
-    action = Column(String(100), nullable=False)
-    details = Column(JSON, nullable=True)
-    ip_address = Column(String(45), nullable=True)
-    user_agent = Column(String(500), nullable=True)
-    status = Column(String(50), nullable=False)  # success, failure
-    error_message = Column(Text, nullable=True)
-    timestamp = Column(DateTime(timezone=True), default=func.now(), nullable=False, index=True)
-    created_at = Column(DateTime(timezone=True), default=func.now(), nullable=False)
-
-    __table_args__ = (
-        Index('idx_audit_logs_user_id', 'user_id'),
-        Index('idx_audit_logs_event_type', 'event_type'),
-        Index('idx_audit_logs_resource_type', 'resource_type'),
-        Index('idx_audit_logs_timestamp', 'timestamp'),
-        Index('idx_audit_logs_severity', 'severity'),
-        {"extend_existing": True},
-    )
-
-    def __repr__(self):
-        return f"<AuditLog(id={self.id}, event_type={self.event_type}, user_id={self.user_id})>"
+# ``AuditLog`` remains importable from this middleware for compatibility.  The
+# canonical ORM model is owned by ``database.models`` so every import order
+# shares one SQLAlchemy table and index definition.
 
 
 # ============================================================================
 # Audit Logger
 # ============================================================================
+
 
 class AuditLogger:
     """Centralized audit logging service"""
@@ -495,6 +462,7 @@ class AuditLogger:
 # Audit Logging Decorator
 # ============================================================================
 
+
 def audit_log(
     event_type: AuditEventType,
     resource_type: str,
@@ -513,6 +481,7 @@ def audit_log(
     Returns:
         Decorated function
     """
+
     def decorator(func):
         @wraps(func)
         async def async_wrapper(*args, **kwargs):
@@ -600,6 +569,7 @@ def audit_log(
 
         # Return appropriate wrapper based on function type
         import inspect
+
         if inspect.iscoroutinefunction(func):
             return async_wrapper
         else:

--- a/apps/backend/src/api/routers/evaluation_workbench.py
+++ b/apps/backend/src/api/routers/evaluation_workbench.py
@@ -13,20 +13,32 @@ from sqlalchemy.orm import Session
 
 from database.connection import get_db
 from api.composition.evaluation_workbench import build_evaluation_workbench_service
+from api.composition.verified_evidence_admission import (
+    build_verified_evidence_admission_service,
+)
+from config.settings import settings
 from src.api.routers.governance_assurance import (
     _require_mutation,
     _service as governance_service,
     organization_membership,
 )
+from src.application.ports.evidence_admission import EvidenceAdmissionScope
 from src.application.services.evaluation_workbench_service import (
     EvaluationWorkbenchError,
     EvaluationWorkbenchInputError,
     EvaluationWorkbenchService,
     canonical_assurance_json,
 )
+from src.application.services.verified_evidence_admission_service import (
+    VerifiedEvidenceAdmissionService,
+)
 from src.application.services.governance_assurance_service import OrgMembership
 
 router = APIRouter(prefix="/organizations/{org_id}", tags=["evaluation-workbench-v2"])
+verified_evidence_router = APIRouter(
+    prefix="/organizations/{org_id}",
+    tags=["evaluation-workbench-v2-evidence"],
+)
 MAX_REQUEST_BYTES = 1024 * 1024
 MAX_JSON_DEPTH = 32
 MAX_JSON_NODES = 20_000
@@ -105,9 +117,7 @@ class ResourceBudgetsV1(StrictModel):
         default=None, alias="maxDurationSeconds", gt=0, le=86_400
     )
     max_cpu_seconds: float | None = Field(default=None, alias="maxCpuSeconds", gt=0, le=86_400)
-    max_memory_mib: int | None = Field(
-        default=None, alias="maxMemoryMiB", ge=1, le=1_048_576
-    )
+    max_memory_mib: int | None = Field(default=None, alias="maxMemoryMiB", ge=1, le=1_048_576)
     max_processes: int | None = Field(default=None, alias="maxProcesses", ge=1, le=4_096)
     max_disk_mib: int | None = Field(default=None, alias="maxDiskMiB", ge=1, le=1_048_576)
     max_input_bytes: int | None = Field(
@@ -327,9 +337,7 @@ class EvaluationRunV2Response(StrictModel):
     technical_status: TechnicalStatus = Field(alias="technicalStatus")
     evidence_outcome: EvidenceResultStatus = Field(alias="evidenceOutcome")
     overall_verdict: GovernanceVerdict = Field(alias="overallVerdict")
-    layer_verdicts_schema_version: Literal["1.0.0"] = Field(
-        alias="layerVerdictsSchemaVersion"
-    )
+    layer_verdicts_schema_version: Literal["1.0.0"] = Field(alias="layerVerdictsSchemaVersion")
     layer_verdicts: LayerVerdictsResponse = Field(alias="layerVerdicts")
     suite_executions: list[SuiteExecutionResponse] = Field(alias="suiteExecutions")
     envelope_id: str = Field(alias="envelopeId")
@@ -343,6 +351,32 @@ class EvaluationRunV2Response(StrictModel):
     failure_message: str | None = Field(alias="failureMessage")
     created_at: str = Field(alias="createdAt")
     updated_at: str = Field(alias="updatedAt")
+
+
+class EvidenceAdmissionResponse(StrictModel):
+    """Safe response projection for one suite-specific verified admission."""
+
+    admission_id: str = Field(alias="admissionId")
+    evidence_run_id: str = Field(alias="evidenceRunId")
+    passport_revision_id: str = Field(alias="passportRevisionId")
+    verification_receipt_id: str = Field(alias="verificationReceiptId")
+    nonce_claim_id: str = Field(alias="nonceClaimId")
+    suite_evidence_link_id: str = Field(alias="suiteEvidenceLinkId")
+    run_id: str = Field(alias="runId")
+    suite_execution_id: str = Field(alias="suiteExecutionId")
+    envelope_hash: str = Field(alias="envelopeHash", pattern="^[0-9a-f]{64}$")
+    passport_content_hash: str = Field(alias="passportContentHash", pattern="^[0-9a-f]{64}$")
+    technical_status: TechnicalStatus = Field(alias="technicalStatus")
+    evidence_result_status: EvidenceResultStatus = Field(alias="evidenceResultStatus")
+    admission_status: AdmissionStatus = Field(alias="admissionStatus")
+    review_status: ReviewStatus = Field(alias="reviewStatus")
+    freshness_status: FreshnessStatus = Field(alias="freshnessStatus")
+    run_technical_status: TechnicalStatus = Field(alias="runTechnicalStatus")
+    run_evidence_outcome: EvidenceResultStatus = Field(alias="runEvidenceOutcome")
+    overall_verdict: GovernanceVerdict = Field(alias="overallVerdict")
+    verdict_version: int = Field(alias="verdictVersion", ge=1)
+    effective_expires_at: str = Field(alias="effectiveExpiresAt")
+    verified_at: str = Field(alias="verifiedAt")
 
 
 def _depth(value: Any, level: int = 0) -> int:
@@ -467,8 +501,74 @@ def _service(db: Session) -> EvaluationWorkbenchService:
     return build_evaluation_workbench_service(db)
 
 
+def get_verified_evidence_admission_service(
+    db: Session = Depends(get_db),
+) -> VerifiedEvidenceAdmissionService:
+    """Compose the admission service only at the gated HTTP boundary."""
+
+    return build_verified_evidence_admission_service(db)
+
+
+def _require_verified_evidence_submit_enabled() -> None:
+    """Hide the route until its independent execution/admission gate passes."""
+
+    if not settings.assurance_v2_evidence_submit_enabled:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "code": "assurance_feature_disabled",
+                "message": "Verified evidence submission is not enabled.",
+            },
+        )
+
+
 def _write(membership: OrgMembership, db: Session) -> None:
     _require_mutation(membership, governance_service(db))
+
+
+def _require_evidence_submit_permission(membership: OrgMembership) -> None:
+    if "evaluation:evidence:submit" not in membership.permissions:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "code": "evaluation_evidence_submit_forbidden",
+                "message": "The evaluation:evidence:submit permission is required.",
+            },
+        )
+
+
+def _require_evidence_scope(
+    *,
+    db: Session,
+    organization_id: str,
+    workspace_id: str,
+    system_id: str,
+    run_id: str,
+    suite_execution_id: str,
+) -> None:
+    """Bind every path identity to the same immutable run and suite record."""
+
+    try:
+        run = _service(db).get_run(
+            org_id=organization_id,
+            system_id=system_id,
+            run_id=run_id,
+        )
+    except EvaluationWorkbenchError as error:
+        _raise(error)
+    if not isinstance(run, dict):
+        _missing("evidence_scope")
+    if (
+        run.get("organizationId") != organization_id
+        or run.get("workspaceId") != workspace_id
+        or run.get("systemId") != system_id
+        or run.get("id") != run_id
+        or not any(
+            isinstance(execution, dict) and execution.get("id") == suite_execution_id
+            for execution in run.get("suiteExecutions", [])
+        )
+    ):
+        _missing("evidence_scope")
 
 
 def _raise(error: EvaluationWorkbenchError) -> None:
@@ -904,3 +1004,82 @@ def get_run(
     if result is None:
         _missing("run")
     return result
+
+
+@verified_evidence_router.post(
+    "/workspaces/{workspace_id}/systems/{system_id}/evaluation-v2/runs/{run_id}"
+    "/suite-executions/{suite_execution_id}/evidence",
+    status_code=201,
+    response_model=EvidenceAdmissionResponse,
+    dependencies=[Depends(_require_verified_evidence_submit_enabled)],
+    openapi_extra={
+        "requestBody": {
+            "required": True,
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "description": "Signed Evidence Passport V2 JSON.",
+                    }
+                }
+            },
+        }
+    },
+)
+async def submit_verified_evidence(
+    org_id: str,
+    workspace_id: str,
+    system_id: str,
+    run_id: str,
+    suite_execution_id: str,
+    request: Request,
+    idempotency_key: str = Header(alias="Idempotency-Key"),
+    membership: OrgMembership = Depends(organization_membership),
+    db: Session = Depends(get_db),
+    admission_service: VerifiedEvidenceAdmissionService = Depends(
+        get_verified_evidence_admission_service
+    ),
+):
+    """Admit one signed Passport to one exact suite execution.
+
+    The submitted bytes remain opaque at this transport boundary. The
+    admission service parses and authenticates them only after resolving the
+    server-owned authority graph for this exact tenant/run/suite scope.
+    """
+
+    _require_evidence_submit_permission(membership)
+    if membership.org_id != org_id:
+        _missing("evidence_scope")
+    _require_evidence_scope(
+        db=db,
+        organization_id=membership.org_id,
+        workspace_id=workspace_id,
+        system_id=system_id,
+        run_id=run_id,
+        suite_execution_id=suite_execution_id,
+    )
+    media_type = request.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+    if media_type != "application/json" and not media_type.endswith("+json"):
+        raise HTTPException(
+            status_code=415,
+            detail={
+                "code": "unsupported_media_type",
+                "message": "Use application/json for a signed Evidence Passport.",
+            },
+        )
+    raw_passport = await _read_request_body(request)
+    try:
+        result = admission_service.admit_verified_passport_v2(
+            scope=EvidenceAdmissionScope(
+                organization_id=membership.org_id,
+                system_id=system_id,
+                run_id=run_id,
+                suite_execution_id=suite_execution_id,
+            ),
+            actor_id=membership.user_id,
+            idempotency_key=idempotency_key,
+            raw_passport=raw_passport,
+        )
+        return _respond(result, EvidenceAdmissionResponse)
+    except EvaluationWorkbenchError as error:
+        _raise(error)

--- a/apps/backend/src/application/services/evaluator_registration.py
+++ b/apps/backend/src/application/services/evaluator_registration.py
@@ -1,0 +1,314 @@
+"""Fail-closed, four-eyes evaluator-registration ceremony contract.
+
+This module intentionally has no persistence, API, or trust-resolution
+dependencies.  It models the server-owned registration ceremony that must
+complete before an evaluator identity can become eligible for admission.  A
+cryptographically valid issuer/key is therefore never sufficient on its own:
+the exact evaluator, adapter, result contract, source, issuer, and key tuple
+must have an approved registration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+import re
+
+_IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+_ALLOWED_SOURCE_TYPES = frozenset({"fairmind_worker", "external_provider"})
+_PENDING = "pending"
+_APPROVED = "approved"
+_REJECTED = "rejected"
+_REVOKED = "revoked"
+_ALL_STATUSES = frozenset({_PENDING, _APPROVED, _REJECTED, _REVOKED})
+_MAX_RATIONALE_LENGTH = 2_000
+
+
+class EvaluatorRegistrationCeremonyError(ValueError):
+    """The registration ceremony cannot create evaluator trust."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def _require_identifier(value: object, *, label: str) -> str:
+    if not isinstance(value, str) or _IDENTIFIER.fullmatch(value) is None:
+        raise EvaluatorRegistrationCeremonyError(
+            "evaluator_registration_invalid",
+            f"The evaluator registration {label} is invalid.",
+        )
+    return value
+
+
+def _require_source_type(value: object) -> str:
+    if not isinstance(value, str) or value not in _ALLOWED_SOURCE_TYPES:
+        raise EvaluatorRegistrationCeremonyError(
+            "evaluator_registration_invalid",
+            "The evaluator registration source type is invalid.",
+        )
+    return value
+
+
+def _require_rationale(value: object, *, label: str) -> str:
+    if not isinstance(value, str):
+        raise EvaluatorRegistrationCeremonyError(
+            "evaluator_registration_invalid",
+            f"The evaluator registration {label} is invalid.",
+        )
+    normalized = value.strip()
+    if not normalized or len(normalized) > _MAX_RATIONALE_LENGTH:
+        raise EvaluatorRegistrationCeremonyError(
+            "evaluator_registration_invalid",
+            f"The evaluator registration {label} is invalid.",
+        )
+    return normalized
+
+
+def _utc(value: object, *, label: str) -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None:
+        raise EvaluatorRegistrationCeremonyError(
+            "evaluator_registration_invalid",
+            f"The evaluator registration {label} is invalid.",
+        )
+    return value.astimezone(timezone.utc)
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluatorIdentityBinding:
+    """The immutable identity tuple that a ceremony approves or rejects."""
+
+    evaluator_id: str
+    source_type: str
+    adapter_name: str
+    adapter_version: str
+    result_contract_version: str
+    issuer_id: str
+    key_id: str
+
+    def __post_init__(self) -> None:
+        for value, label in (
+            (self.evaluator_id, "evaluator id"),
+            (self.adapter_name, "adapter name"),
+            (self.adapter_version, "adapter version"),
+            (self.result_contract_version, "result contract version"),
+            (self.issuer_id, "issuer id"),
+            (self.key_id, "key id"),
+        ):
+            _require_identifier(value, label=label)
+        _require_source_type(self.source_type)
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluatorRegistrationRecord:
+    """Immutable registration state; only the ceremony creates transitions."""
+
+    registration_id: str
+    binding: EvaluatorIdentityBinding
+    status: str
+    submitted_by: str
+    submitted_at: datetime
+    reviewed_by: str | None = None
+    reviewed_at: datetime | None = None
+    review_rationale: str | None = None
+    revoked_by: str | None = None
+    revoked_at: datetime | None = None
+    revocation_rationale: str | None = None
+
+    def __post_init__(self) -> None:
+        _require_identifier(self.registration_id, label="id")
+        if not isinstance(self.binding, EvaluatorIdentityBinding):
+            raise EvaluatorRegistrationCeremonyError(
+                "evaluator_registration_invalid",
+                "The evaluator registration binding is invalid.",
+            )
+        if self.status not in _ALL_STATUSES:
+            raise EvaluatorRegistrationCeremonyError(
+                "evaluator_registration_invalid",
+                "The evaluator registration status is invalid.",
+            )
+        _require_identifier(self.submitted_by, label="submitter")
+        submitted_at = _utc(self.submitted_at, label="submission timestamp")
+        object.__setattr__(self, "submitted_at", submitted_at)
+
+        review_fields = (self.reviewed_by, self.reviewed_at, self.review_rationale)
+        has_review = any(value is not None for value in review_fields)
+        if self.status == _PENDING:
+            if has_review or any(
+                value is not None
+                for value in (self.revoked_by, self.revoked_at, self.revocation_rationale)
+            ):
+                raise EvaluatorRegistrationCeremonyError(
+                    "evaluator_registration_invalid",
+                    "A pending evaluator registration cannot include a decision or revocation.",
+                )
+            return
+
+        if not all(value is not None for value in review_fields):
+            raise EvaluatorRegistrationCeremonyError(
+                "evaluator_registration_invalid",
+                "A decided evaluator registration requires a complete review record.",
+            )
+        reviewed_by = _require_identifier(self.reviewed_by, label="reviewer")
+        reviewed_at = _utc(self.reviewed_at, label="review timestamp")
+        review_rationale = _require_rationale(self.review_rationale, label="review rationale")
+        if reviewed_by == self.submitted_by:
+            raise EvaluatorRegistrationCeremonyError(
+                "evaluator_registration_four_eyes_required",
+                "The evaluator registration reviewer must differ from the submitter.",
+            )
+        if reviewed_at < submitted_at:
+            raise EvaluatorRegistrationCeremonyError(
+                "evaluator_registration_invalid",
+                "The evaluator registration review precedes submission.",
+            )
+        object.__setattr__(self, "reviewed_by", reviewed_by)
+        object.__setattr__(self, "reviewed_at", reviewed_at)
+        object.__setattr__(self, "review_rationale", review_rationale)
+
+        revocation_fields = (self.revoked_by, self.revoked_at, self.revocation_rationale)
+        has_revocation = any(value is not None for value in revocation_fields)
+        if self.status in {_APPROVED, _REJECTED}:
+            if has_revocation:
+                raise EvaluatorRegistrationCeremonyError(
+                    "evaluator_registration_invalid",
+                    "An active or rejected evaluator registration cannot include revocation details.",
+                )
+            return
+
+        if not all(value is not None for value in revocation_fields):
+            raise EvaluatorRegistrationCeremonyError(
+                "evaluator_registration_invalid",
+                "A revoked evaluator registration requires complete revocation details.",
+            )
+        revoked_by = _require_identifier(self.revoked_by, label="revoker")
+        revoked_at = _utc(self.revoked_at, label="revocation timestamp")
+        revocation_rationale = _require_rationale(
+            self.revocation_rationale,
+            label="revocation rationale",
+        )
+        if revoked_at < reviewed_at:
+            raise EvaluatorRegistrationCeremonyError(
+                "evaluator_registration_invalid",
+                "The evaluator registration revocation precedes its review.",
+            )
+        object.__setattr__(self, "revoked_by", revoked_by)
+        object.__setattr__(self, "revoked_at", revoked_at)
+        object.__setattr__(self, "revocation_rationale", revocation_rationale)
+
+
+class EvaluatorRegistrationCeremony:
+    """Create lifecycle transitions without treating a signer key as trust."""
+
+    @staticmethod
+    def submit(
+        *,
+        registration_id: str,
+        binding: EvaluatorIdentityBinding,
+        submitted_by: str,
+        submitted_at: datetime,
+    ) -> EvaluatorRegistrationRecord:
+        return EvaluatorRegistrationRecord(
+            registration_id=registration_id,
+            binding=binding,
+            status=_PENDING,
+            submitted_by=submitted_by,
+            submitted_at=submitted_at,
+        )
+
+    @staticmethod
+    def approve(
+        record: EvaluatorRegistrationRecord,
+        *,
+        approved_by: str,
+        approved_at: datetime,
+        rationale: str,
+    ) -> EvaluatorRegistrationRecord:
+        EvaluatorRegistrationCeremony._require_pending(record)
+        return replace(
+            record,
+            status=_APPROVED,
+            reviewed_by=approved_by,
+            reviewed_at=approved_at,
+            review_rationale=rationale,
+        )
+
+    @staticmethod
+    def reject(
+        record: EvaluatorRegistrationRecord,
+        *,
+        rejected_by: str,
+        rejected_at: datetime,
+        rationale: str,
+    ) -> EvaluatorRegistrationRecord:
+        EvaluatorRegistrationCeremony._require_pending(record)
+        return replace(
+            record,
+            status=_REJECTED,
+            reviewed_by=rejected_by,
+            reviewed_at=rejected_at,
+            review_rationale=rationale,
+        )
+
+    @staticmethod
+    def revoke(
+        record: EvaluatorRegistrationRecord,
+        *,
+        revoked_by: str,
+        revoked_at: datetime,
+        rationale: str,
+    ) -> EvaluatorRegistrationRecord:
+        if not isinstance(record, EvaluatorRegistrationRecord) or record.status != _APPROVED:
+            raise EvaluatorRegistrationCeremonyError(
+                "evaluator_registration_transition_invalid",
+                "Only an approved evaluator registration can be revoked.",
+            )
+        return replace(
+            record,
+            status=_REVOKED,
+            revoked_by=revoked_by,
+            revoked_at=revoked_at,
+            revocation_rationale=rationale,
+        )
+
+    @staticmethod
+    def require_approved_binding(
+        record: EvaluatorRegistrationRecord,
+        *,
+        binding: EvaluatorIdentityBinding,
+    ) -> EvaluatorRegistrationRecord:
+        """Return only a specifically approved identity tuple for admission use.
+
+        Signature/key verification is deliberately absent from this interface.
+        Callers must perform that independently and still provide the exact
+        server-owned registration returned by their persistence boundary.
+        """
+
+        if not isinstance(record, EvaluatorRegistrationRecord) or record.status != _APPROVED:
+            raise EvaluatorRegistrationCeremonyError(
+                "evaluator_registration_not_approved",
+                "The evaluator registration is not approved for evidence admission.",
+            )
+        if not isinstance(binding, EvaluatorIdentityBinding) or record.binding != binding:
+            raise EvaluatorRegistrationCeremonyError(
+                "evaluator_registration_binding_mismatch",
+                "The evaluator identity does not match its approved registration.",
+            )
+        return record
+
+    @staticmethod
+    def _require_pending(record: EvaluatorRegistrationRecord) -> None:
+        if not isinstance(record, EvaluatorRegistrationRecord) or record.status != _PENDING:
+            raise EvaluatorRegistrationCeremonyError(
+                "evaluator_registration_transition_invalid",
+                "Only a pending evaluator registration can be decided.",
+            )
+
+
+__all__ = [
+    "EvaluatorIdentityBinding",
+    "EvaluatorRegistrationCeremony",
+    "EvaluatorRegistrationCeremonyError",
+    "EvaluatorRegistrationRecord",
+]

--- a/apps/backend/src/application/services/evaluator_registry.py
+++ b/apps/backend/src/application/services/evaluator_registry.py
@@ -1,0 +1,189 @@
+"""Server-owned evaluator registrations for Evidence Passport V2 admission.
+
+The registry is deliberately separate from submitted Passport data.  A signed
+``evaluatorId`` is only eligible when the server has an active registration
+whose adapter, source, and result contract exactly match the locked suite.
+This first implementation is an immutable in-process catalog; persistence and
+registration ceremonies remain a later, separately reviewed boundary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+import re
+from types import MappingProxyType
+from typing import Protocol
+
+from src.domain.assurance.evaluation_v2 import canonical_sha256
+
+_IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+_ALLOWED_SOURCES = frozenset({"fairmind_worker", "external_provider"})
+_ALLOWED_STATUSES = frozenset({"active", "deprecated", "revoked"})
+
+
+class EvaluatorRegistryError(ValueError):
+    """A server-owned evaluator registration cannot authorize a binding."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+class EvaluatorRegistry(Protocol):
+    """Application port for a server-owned evaluator catalog."""
+
+    catalog_hash: str
+
+    def validate_binding(
+        self,
+        *,
+        evaluator_id: str,
+        source_type: str,
+        adapter_name: str,
+        adapter_version: str,
+        result_contract_version: str,
+    ) -> EvaluatorRegistration: ...
+
+
+def _require_identifier(value: object, *, label: str) -> str:
+    if not isinstance(value, str) or _IDENTIFIER.fullmatch(value) is None:
+        raise EvaluatorRegistryError(
+            "evaluator_registration_invalid",
+            f"The evaluator {label} is invalid.",
+        )
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluatorRegistration:
+    """One immutable server-owned evaluator identity and compatibility tuple."""
+
+    evaluator_id: str
+    adapter_name: str
+    adapter_version: str
+    result_contract_version: str
+    source_types: frozenset[str]
+    status: str = "active"
+
+    def __post_init__(self) -> None:
+        for value, label in (
+            (self.evaluator_id, "id"),
+            (self.adapter_name, "adapter name"),
+            (self.adapter_version, "adapter version"),
+            (self.result_contract_version, "result contract version"),
+        ):
+            _require_identifier(value, label=label)
+        if self.status not in _ALLOWED_STATUSES:
+            raise EvaluatorRegistryError(
+                "evaluator_registration_invalid",
+                "The evaluator status is invalid.",
+            )
+        if not isinstance(self.source_types, frozenset) or not self.source_types:
+            raise EvaluatorRegistryError(
+                "evaluator_registration_invalid",
+                "An evaluator must allow at least one delivery source.",
+            )
+        if not self.source_types.issubset(_ALLOWED_SOURCES):
+            raise EvaluatorRegistryError(
+                "evaluator_registration_invalid",
+                "The evaluator source allowlist is invalid.",
+            )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "evaluatorId": self.evaluator_id,
+            "adapterName": self.adapter_name,
+            "adapterVersion": self.adapter_version,
+            "resultContractVersion": self.result_contract_version,
+            "sourceTypes": sorted(self.source_types),
+            "status": self.status,
+        }
+
+
+class StaticEvaluatorRegistry:
+    """An immutable server-owned catalog used before persistent registration."""
+
+    def __init__(
+        self,
+        *,
+        catalog_version: str,
+        registrations: Iterable[EvaluatorRegistration],
+    ) -> None:
+        self.catalog_version = _require_identifier(catalog_version, label="catalog version")
+        by_id: dict[str, EvaluatorRegistration] = {}
+        for registration in registrations:
+            if not isinstance(registration, EvaluatorRegistration):
+                raise EvaluatorRegistryError(
+                    "evaluator_registration_invalid",
+                    "The evaluator catalog contains an invalid registration.",
+                )
+            if registration.evaluator_id in by_id:
+                raise EvaluatorRegistryError(
+                    "evaluator_registration_duplicate",
+                    f"The evaluator catalog contains a duplicate registration for {registration.evaluator_id}.",
+                )
+            by_id[registration.evaluator_id] = registration
+        self._registrations = MappingProxyType(by_id)
+        self.catalog_hash = canonical_sha256(
+            {
+                "catalogVersion": self.catalog_version,
+                "registrations": [
+                    registration.to_dict()
+                    for registration in sorted(by_id.values(), key=lambda item: item.evaluator_id)
+                ],
+            }
+        )
+
+    def resolve(self, evaluator_id: str) -> EvaluatorRegistration | None:
+        """Return a catalog row without treating it as authorized."""
+
+        return self._registrations.get(evaluator_id)
+
+    def validate_binding(
+        self,
+        *,
+        evaluator_id: str,
+        source_type: str,
+        adapter_name: str,
+        adapter_version: str,
+        result_contract_version: str,
+    ) -> EvaluatorRegistration:
+        """Fail closed unless the exact signed/locked compatibility tuple is catalogued."""
+
+        evaluator_id = _require_identifier(evaluator_id, label="id")
+        registration = self.resolve(evaluator_id)
+        if registration is None:
+            raise EvaluatorRegistryError(
+                "evaluator_unregistered",
+                "The evaluator is not registered by FairMind.",
+            )
+        if registration.status != "active":
+            raise EvaluatorRegistryError(
+                "evaluator_inactive",
+                "The evaluator registration is not active.",
+            )
+        if source_type not in registration.source_types:
+            raise EvaluatorRegistryError(
+                "evaluator_source_not_allowed",
+                "The evaluator is not authorized for this delivery source.",
+            )
+        if (
+            adapter_name != registration.adapter_name
+            or adapter_version != registration.adapter_version
+            or result_contract_version != registration.result_contract_version
+        ):
+            raise EvaluatorRegistryError(
+                "evaluator_binding_mismatch",
+                "The evaluator binding does not match its server registration.",
+            )
+        return registration
+
+
+__all__ = [
+    "EvaluatorRegistration",
+    "EvaluatorRegistry",
+    "EvaluatorRegistryError",
+    "StaticEvaluatorRegistry",
+]

--- a/apps/backend/src/application/services/verified_evidence_admission_service.py
+++ b/apps/backend/src/application/services/verified_evidence_admission_service.py
@@ -36,6 +36,11 @@ from src.application.services.evidence_authenticity_service import (
     EvidenceAuthenticityError,
     EvidenceAuthenticityService,
 )
+from src.application.services.evaluator_registry import (
+    EvaluatorRegistration,
+    EvaluatorRegistry,
+    EvaluatorRegistryError,
+)
 from src.application.services.trusted_evidence_admission_resolver import (
     TrustedEvidenceAdmissionResolver,
 )
@@ -174,7 +179,27 @@ def _evaluator_projection(passport: Mapping[str, object]) -> dict[str, object]:
 def _verify_evaluator_binding(
     context: TrustedEvidenceAdmissionContext,
     evaluator: Mapping[str, object],
-) -> None:
+    evaluator_registry: EvaluatorRegistry,
+) -> EvaluatorRegistration:
+    try:
+        registration = evaluator_registry.validate_binding(
+            evaluator_id=evaluator["evaluatorId"],
+            source_type=evaluator["sourceType"],
+            adapter_name=evaluator["adapterName"],
+            adapter_version=evaluator["adapterVersion"],
+            result_contract_version=evaluator["resultContractVersion"],
+        )
+    except EvaluatorRegistryError as error:
+        mapped_code = {
+            "evaluator_unregistered": "evidence_evaluator_unregistered",
+            "evaluator_inactive": "evidence_evaluator_inactive",
+            "evaluator_source_not_allowed": "evidence_evaluator_source_untrusted",
+        }.get(error.code, "evidence_evaluator_binding_mismatch")
+        raise _error(
+            mapped_code,
+            "The signed evaluator is not authorized by the server catalog.",
+            status_code=409,
+        ) from None
     _, suite = _selected_suite(context)
     expected = {
         "issuerId": context.authority.issuer_key,
@@ -190,6 +215,7 @@ def _verify_evaluator_binding(
             "evidence_evaluator_binding_mismatch",
             "The signed evaluator does not match the locked suite authority.",
         )
+    return registration
 
 
 def _verify_stable_authority(
@@ -343,12 +369,14 @@ class VerifiedEvidenceAdmissionService:
         self,
         unit_of_work: EvidenceAdmissionUnitOfWork,
         authenticity_service: EvidenceAuthenticityService,
+        evaluator_registry: EvaluatorRegistry,
         *,
         uuid_factory: UuidFactory = uuid.uuid4,
     ) -> None:
         self._unit_of_work = unit_of_work
         self._repository = unit_of_work.repository
         self._authenticity = authenticity_service
+        self._evaluator_registry = evaluator_registry
         self._resolver = TrustedEvidenceAdmissionResolver(self._repository)
         self._uuid_factory = uuid_factory
 
@@ -469,14 +497,27 @@ class VerifiedEvidenceAdmissionService:
                 )
 
             evaluator = _evaluator_projection(passport)
-            _verify_evaluator_binding(initial, evaluator)
+            initial_registration = _verify_evaluator_binding(
+                initial,
+                evaluator,
+                self._evaluator_registry,
+            )
             verified = self._resolver.resolve(
                 scope=scope,
                 issuer_key=issuer_key,
                 signer_key_id=signer_key_id,
             )
             _verify_stable_authority(initial, verified)
-            _verify_evaluator_binding(verified, evaluator)
+            verified_registration = _verify_evaluator_binding(
+                verified,
+                evaluator,
+                self._evaluator_registry,
+            )
+            if initial_registration != verified_registration:
+                raise _error(
+                    "evidence_evaluator_registry_changed",
+                    "The server evaluator catalog changed during verification.",
+                )
             return self._persist_verified(
                 scope=scope,
                 actor_id=actor_id,
@@ -485,6 +526,7 @@ class VerifiedEvidenceAdmissionService:
                 evaluator=evaluator,
                 initial=initial,
                 verified=verified,
+                evaluator_registration=verified_registration,
             )
 
         return self._unit_of_work.mutate(command, admit)
@@ -499,6 +541,7 @@ class VerifiedEvidenceAdmissionService:
         evaluator: Mapping[str, object],
         initial: TrustedEvidenceAdmissionContext,
         verified: TrustedEvidenceAdmissionContext,
+        evaluator_registration: EvaluatorRegistration,
     ) -> MutationOutcome:
         authority = verified.authority
         run = authority.run
@@ -751,6 +794,8 @@ class VerifiedEvidenceAdmissionService:
             "freshnessStatus": record.freshness_status,
             "runTechnicalStatus": record.run_technical_status,
             "runEvidenceOutcome": record.run_evidence_outcome,
+            "evaluatorRegistryHash": self._evaluator_registry.catalog_hash,
+            "evaluatorRegistrationHash": canonical_sha256(evaluator_registration.to_dict()),
         }
         return MutationOutcome(
             body=FrozenJsonObject.from_mapping(body),

--- a/apps/backend/tests/test_api_main_assurance_v2_route_gate.py
+++ b/apps/backend/tests/test_api_main_assurance_v2_route_gate.py
@@ -12,6 +12,11 @@ V2_PLAN_PATH = (
     "/api/v1/ai-governance/organizations/{org_id}/systems/{system_id}"
     "/evaluation-v2/plans"
 )
+VERIFIED_EVIDENCE_PATH = (
+    "/api/v1/ai-governance/organizations/{org_id}/workspaces/{workspace_id}"
+    "/systems/{system_id}/evaluation-v2/runs/{run_id}"
+    "/suite-executions/{suite_execution_id}/evidence"
+)
 LEGACY_PLAN_PATH = (
     "/api/v1/ai-governance/organizations/{org_id}/systems/{system_id}"
     "/evaluation-plans"
@@ -32,22 +37,33 @@ def _assurance_v2_paths(paths: set[str]) -> set[str]:
 
 def test_assurance_v2_routes_are_mounted_only_when_enabled() -> None:
     original = settings.assurance_v2_enabled
+    original_evidence_submit = settings.assurance_v2_evidence_submit_enabled
     try:
         settings.assurance_v2_enabled = False
+        settings.assurance_v2_evidence_submit_enabled = False
         importlib.reload(main_module)
         disabled_paths = _route_paths()
 
         assert _assurance_v2_paths(disabled_paths) == set()
+        assert VERIFIED_EVIDENCE_PATH not in disabled_paths
         assert LEGACY_PLAN_PATH in disabled_paths
         assert LEGACY_RUN_PATH in disabled_paths
 
         settings.assurance_v2_enabled = True
+        settings.assurance_v2_evidence_submit_enabled = False
+        importlib.reload(main_module)
+        enabled_paths_without_evidence_submit = _route_paths()
+
+        assert V2_PLAN_PATH in _assurance_v2_paths(enabled_paths_without_evidence_submit)
+        assert VERIFIED_EVIDENCE_PATH not in enabled_paths_without_evidence_submit
+        assert LEGACY_PLAN_PATH in enabled_paths_without_evidence_submit
+        assert LEGACY_RUN_PATH in enabled_paths_without_evidence_submit
+
+        settings.assurance_v2_evidence_submit_enabled = True
         importlib.reload(main_module)
         enabled_paths = _route_paths()
-
-        assert V2_PLAN_PATH in _assurance_v2_paths(enabled_paths)
-        assert LEGACY_PLAN_PATH in enabled_paths
-        assert LEGACY_RUN_PATH in enabled_paths
+        assert VERIFIED_EVIDENCE_PATH in enabled_paths
     finally:
         settings.assurance_v2_enabled = original
+        settings.assurance_v2_evidence_submit_enabled = original_evidence_submit
         importlib.reload(main_module)

--- a/apps/backend/tests/test_backend_model_composition.py
+++ b/apps/backend/tests/test_backend_model_composition.py
@@ -1,0 +1,13 @@
+"""Regression coverage for active backend model composition."""
+
+from api.middleware.audit_logging import AuditLog as MiddlewareAuditLog
+from database.models import AuditLog as DatabaseAuditLog
+
+
+def test_audit_logging_reexports_the_canonical_audit_model():
+    """The middleware import must not create a second audit_logs table."""
+    assert MiddlewareAuditLog is DatabaseAuditLog
+    assert MiddlewareAuditLog.__table__.name == "audit_logs"
+    assert [index.name for index in MiddlewareAuditLog.__table__.indexes].count(
+        "ix_audit_logs_user_id"
+    ) == 1

--- a/apps/backend/tests/test_evaluation_workbench_routes.py
+++ b/apps/backend/tests/test_evaluation_workbench_routes.py
@@ -15,9 +15,13 @@ from sqlalchemy import create_engine, event, func, select, text
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from api.routes.evaluation_workbench import router as evaluation_workbench_router
+from api.routes.evaluation_workbench import (
+    router as evaluation_workbench_router,
+    verified_evidence_router,
+)
 from api.routes.governance_assurance import router as governance_assurance_router
 from config.auth import TokenData, TokenType, UserRole, get_current_active_user
+from config.settings import settings
 from database.connection import Base, get_db
 from database.governance_models import (
     GovernanceAISystem,
@@ -31,8 +35,10 @@ from database.governance_models import (
     GovernanceIdempotencyRecord,
     GovernanceWorkspace,
 )
-from database.models import Organization, OrganizationMember, User
+from database.models import Organization, OrganizationMember, OrganizationRole, User
 from src.domain.assurance.evaluation_v2 import canonical_json, canonical_sha256
+from src.application.ports.evaluation_workbench import MutationResult
+from api.routes.evaluation_workbench import get_verified_evidence_admission_service
 from tests.evaluation_workbench_sqlite import (
     allow_deliberate_check_constraint_corruption,
     install_authoritative_assurance_fixtures_for_application_verifier_harness,
@@ -48,6 +54,11 @@ app.include_router(
     evaluation_workbench_router,
     prefix="/api/v1/ai-governance",
     tags=["evaluation-workbench-v2"],
+)
+app.include_router(
+    verified_evidence_router,
+    prefix="/api/v1/ai-governance",
+    tags=["evaluation-workbench-v2-evidence"],
 )
 
 ORG = str(uuid.uuid4())
@@ -209,6 +220,72 @@ def _headers(key: str) -> dict[str, str]:
     return {"Idempotency-Key": key}
 
 
+def _admission_url(
+    *,
+    run_id: str,
+    suite_execution_id: str,
+    workspace_id: str = "workspace-a",
+    system_id: str = "system-a",
+    org_id: str = ORG,
+) -> str:
+    return (
+        f"/api/v1/ai-governance/organizations/{org_id}/workspaces/{workspace_id}"
+        f"/systems/{system_id}/evaluation-v2/runs/{run_id}"
+        f"/suite-executions/{suite_execution_id}/evidence"
+    )
+
+
+def _grant_evidence_submit_permission() -> None:
+    session_iterator = app.dependency_overrides[get_db]()
+    session = next(session_iterator)
+    try:
+        session.execute(
+            OrganizationRole.__table__.insert().values(
+                id=uuid.uuid4(),
+                org_id=uuid.UUID(ORG),
+                name="admin",
+                permissions=["evaluation:evidence:submit"],
+            )
+        )
+        session.commit()
+    finally:
+        session_iterator.close()
+
+
+class _RecordingAdmissionService:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def admit_verified_passport_v2(self, **kwargs):
+        self.calls.append(kwargs)
+        return MutationResult.create(
+            body={
+                "admissionId": "admission-1",
+                "evidenceRunId": "evidence-run-1",
+                "passportRevisionId": "passport-revision-1",
+                "verificationReceiptId": "receipt-1",
+                "nonceClaimId": "nonce-1",
+                "suiteEvidenceLinkId": "suite-link-1",
+                "runId": kwargs["scope"].run_id,
+                "suiteExecutionId": kwargs["scope"].suite_execution_id,
+                "envelopeHash": "a" * 64,
+                "passportContentHash": "b" * 64,
+                "technicalStatus": "succeeded",
+                "evidenceResultStatus": "passed",
+                "admissionStatus": "verified",
+                "reviewStatus": "pending",
+                "freshnessStatus": "current",
+                "runTechnicalStatus": "succeeded",
+                "runEvidenceOutcome": "passed",
+                "overallVerdict": "review",
+                "verdictVersion": 1,
+                "effectiveExpiresAt": "2026-08-08T12:00:00+00:00",
+                "verifiedAt": "2026-08-08T11:00:00+00:00",
+            },
+            status=201,
+        )
+
+
 def _target_payload() -> dict:
     return {
         "targetKey": "agent-prod",
@@ -311,6 +388,101 @@ def _create_active_v2_plan_and_run(
     )
     assert created_run.status_code == 201, created_run.text
     return plan, created_run.json()
+
+
+def test_verified_evidence_submit_is_hidden_when_feature_flag_is_off(
+    workbench_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _ = workbench_client
+    monkeypatch.setattr(settings, "assurance_v2_evidence_submit_enabled", False)
+
+    response = client.post(
+        _admission_url(run_id="run-not-visible", suite_execution_id="suite-not-visible"),
+        headers={**_headers("evidence-hidden"), "Content-Type": "application/json"},
+        content=b"{}",
+    )
+
+    assert response.status_code == 404
+
+
+def test_verified_evidence_submit_requires_explicit_permission_and_exact_scope(
+    workbench_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, _ = workbench_client
+    monkeypatch.setattr(settings, "assurance_v2_evidence_submit_enabled", True)
+    _plan, run = _create_active_v2_plan_and_run(client)
+    suite_execution_id = run["suiteExecutions"][0]["id"]
+    valid_url = _admission_url(run_id=run["id"], suite_execution_id=suite_execution_id)
+    request_headers = {**_headers("evidence-boundary"), "Content-Type": "application/json"}
+
+    denied = client.post(valid_url, headers=request_headers, content=b"signed-passport")
+    assert denied.status_code == 403
+    assert denied.json()["detail"]["code"] == "evaluation_evidence_submit_forbidden"
+
+    _grant_evidence_submit_permission()
+    recorder = _RecordingAdmissionService()
+    app.dependency_overrides[get_verified_evidence_admission_service] = lambda: recorder
+    try:
+        wrong_workspace = client.post(
+            _admission_url(
+                run_id=run["id"],
+                suite_execution_id=suite_execution_id,
+                workspace_id="workspace-wrong",
+            ),
+            headers=request_headers,
+            content=b"signed-passport",
+        )
+        assert wrong_workspace.status_code == 404
+
+        wrong_suite = client.post(
+            _admission_url(run_id=run["id"], suite_execution_id="suite-wrong"),
+            headers=request_headers,
+            content=b"signed-passport",
+        )
+        assert wrong_suite.status_code == 404
+
+        accepted = client.post(valid_url, headers=request_headers, content=b"signed-passport")
+        assert accepted.status_code == 201, accepted.text
+        assert len(recorder.calls) == 1
+        call = recorder.calls[0]
+        assert call["actor_id"] == USER
+        assert call["idempotency_key"] == "evidence-boundary"
+        assert call["raw_passport"] == b"signed-passport"
+        assert call["scope"].organization_id == ORG
+        assert call["scope"].system_id == "system-a"
+        assert call["scope"].run_id == run["id"]
+        assert call["scope"].suite_execution_id == suite_execution_id
+    finally:
+        app.dependency_overrides.pop(get_verified_evidence_admission_service, None)
+
+
+def test_verified_evidence_submit_rejects_oversized_body_before_service(
+    workbench_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.api.routers.evaluation_workbench import MAX_REQUEST_BYTES
+
+    client, _ = workbench_client
+    monkeypatch.setattr(settings, "assurance_v2_evidence_submit_enabled", True)
+    _plan, run = _create_active_v2_plan_and_run(client)
+    suite_execution_id = run["suiteExecutions"][0]["id"]
+    _grant_evidence_submit_permission()
+    recorder = _RecordingAdmissionService()
+    app.dependency_overrides[get_verified_evidence_admission_service] = lambda: recorder
+    try:
+        response = client.post(
+            _admission_url(run_id=run["id"], suite_execution_id=suite_execution_id),
+            headers={**_headers("evidence-oversize"), "Content-Type": "application/json"},
+            content=b"x" * (MAX_REQUEST_BYTES + 1),
+        )
+    finally:
+        app.dependency_overrides.pop(get_verified_evidence_admission_service, None)
+
+    assert response.status_code == 413
+    assert response.json()["detail"]["code"] == "request_too_large"
+    assert recorder.calls == []
 
 
 def test_complete_additive_route_flow_and_three_axis_run(workbench_client) -> None:
@@ -1053,6 +1225,17 @@ def test_openapi_exposes_strict_request_and_response_contracts() -> None:
     ):
         assert_refs_resolve(operation["requestBody"])
         assert_refs_resolve(operation["responses"])
+
+    evidence_path = (
+        f"{prefix}/workspaces/{{workspace_id}}/systems/{{system_id}}"
+        "/evaluation-v2/runs/{run_id}/suite-executions/{suite_execution_id}/evidence"
+    )
+    evidence_operation = document["paths"][evidence_path]["post"]
+    assert evidence_operation["requestBody"]["required"] is True
+    assert "application/json" in evidence_operation["requestBody"]["content"]
+    assert evidence_operation["responses"]["201"]["content"]["application/json"]["schema"] == {
+        "$ref": "#/components/schemas/EvidenceAdmissionResponse"
+    }
 
 
 def test_suite_configuration_is_omittable_but_never_nullable(workbench_client) -> None:

--- a/apps/backend/tests/test_evaluator_registration_ceremony.py
+++ b/apps/backend/tests/test_evaluator_registration_ceremony.py
@@ -1,0 +1,152 @@
+"""Four-eyes lifecycle for server-owned evaluator registrations."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.application.services.evaluator_registration import (
+    EvaluatorIdentityBinding,
+    EvaluatorRegistrationCeremony,
+    EvaluatorRegistrationCeremonyError,
+    EvaluatorRegistrationRecord,
+)
+
+NOW = datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)
+
+
+def _binding(*, key_id: str = "inspect-key-2026") -> EvaluatorIdentityBinding:
+    return EvaluatorIdentityBinding(
+        evaluator_id="inspect-agent-safety",
+        source_type="external_provider",
+        adapter_name="inspect",
+        adapter_version="0.3.0",
+        result_contract_version="1.0.0",
+        issuer_id="inspect-provider",
+        key_id=key_id,
+    )
+
+
+def _pending() -> EvaluatorRegistrationRecord:
+    return EvaluatorRegistrationCeremony.submit(
+        registration_id="registration-inspect-2026",
+        binding=_binding(),
+        submitted_by="security-owner",
+        submitted_at=NOW,
+    )
+
+
+def test_approval_requires_a_distinct_submitter_and_approver() -> None:
+    pending = _pending()
+
+    with pytest.raises(EvaluatorRegistrationCeremonyError) as caught:
+        EvaluatorRegistrationCeremony.approve(
+            pending,
+            approved_by="security-owner",
+            approved_at=NOW,
+            rationale="Independent reviewer approved the evaluator identity.",
+        )
+
+    assert caught.value.code == "evaluator_registration_four_eyes_required"
+
+    approved = EvaluatorRegistrationCeremony.approve(
+        pending,
+        approved_by="assurance-reviewer",
+        approved_at=NOW,
+        rationale="Independent reviewer approved the evaluator identity.",
+    )
+
+    assert approved.status == "approved"
+    assert approved.submitted_by == "security-owner"
+    assert approved.reviewed_by == "assurance-reviewer"
+
+
+def test_pending_or_rejected_registration_is_not_trusted_by_matching_key_identity() -> None:
+    pending = _pending()
+
+    with pytest.raises(EvaluatorRegistrationCeremonyError) as pending_error:
+        EvaluatorRegistrationCeremony.require_approved_binding(
+            pending,
+            binding=_binding(),
+        )
+
+    assert pending_error.value.code == "evaluator_registration_not_approved"
+
+    rejected = EvaluatorRegistrationCeremony.reject(
+        pending,
+        rejected_by="assurance-reviewer",
+        rejected_at=NOW,
+        rationale="The evaluator has not completed independent validation.",
+    )
+
+    with pytest.raises(EvaluatorRegistrationCeremonyError) as rejected_error:
+        EvaluatorRegistrationCeremony.require_approved_binding(
+            rejected,
+            binding=_binding(),
+        )
+
+    assert rejected_error.value.code == "evaluator_registration_not_approved"
+
+
+def test_only_an_approved_exact_binding_is_authorized() -> None:
+    approved = EvaluatorRegistrationCeremony.approve(
+        _pending(),
+        approved_by="assurance-reviewer",
+        approved_at=NOW,
+        rationale="Independent reviewer approved the evaluator identity.",
+    )
+
+    assert (
+        EvaluatorRegistrationCeremony.require_approved_binding(
+            approved,
+            binding=_binding(),
+        )
+        == approved
+    )
+
+    with pytest.raises(EvaluatorRegistrationCeremonyError) as caught:
+        EvaluatorRegistrationCeremony.require_approved_binding(
+            approved,
+            binding=_binding(key_id="inspect-key-rotated"),
+        )
+
+    assert caught.value.code == "evaluator_registration_binding_mismatch"
+
+
+def test_only_approved_registration_can_be_revoked_and_never_reauthorized() -> None:
+    pending = _pending()
+
+    with pytest.raises(EvaluatorRegistrationCeremonyError) as pending_error:
+        EvaluatorRegistrationCeremony.revoke(
+            pending,
+            revoked_by="trust-admin",
+            revoked_at=NOW,
+            rationale="Key rotation is required.",
+        )
+
+    assert pending_error.value.code == "evaluator_registration_transition_invalid"
+
+    approved = EvaluatorRegistrationCeremony.approve(
+        pending,
+        approved_by="assurance-reviewer",
+        approved_at=NOW,
+        rationale="Independent reviewer approved the evaluator identity.",
+    )
+    revoked = EvaluatorRegistrationCeremony.revoke(
+        approved,
+        revoked_by="trust-admin",
+        revoked_at=NOW,
+        rationale="Key rotation is required.",
+    )
+
+    assert revoked.status == "revoked"
+    assert revoked.revoked_by == "trust-admin"
+
+    with pytest.raises(EvaluatorRegistrationCeremonyError) as revoked_error:
+        EvaluatorRegistrationCeremony.require_approved_binding(
+            revoked,
+            binding=_binding(),
+        )
+
+    assert revoked_error.value.code == "evaluator_registration_not_approved"

--- a/apps/backend/tests/test_evaluator_registry.py
+++ b/apps/backend/tests/test_evaluator_registry.py
@@ -1,0 +1,105 @@
+"""Server-owned evaluator catalog bindings fail closed."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.application.services.evaluator_registry import (
+    EvaluatorRegistryError,
+    EvaluatorRegistration,
+    StaticEvaluatorRegistry,
+)
+
+
+def _registry(*, status: str = "active") -> StaticEvaluatorRegistry:
+    return StaticEvaluatorRegistry(
+        catalog_version="2026.08.1",
+        registrations=(
+            EvaluatorRegistration(
+                evaluator_id="inspect-agent-safety",
+                adapter_name="inspect",
+                adapter_version="0.3.0",
+                result_contract_version="1.0.0",
+                source_types=frozenset({"external_provider", "fairmind_worker"}),
+                status=status,
+            ),
+        ),
+    )
+
+
+def test_registry_returns_immutable_authorized_registration_and_catalog_hash() -> None:
+    registry = _registry()
+
+    registration = registry.validate_binding(
+        evaluator_id="inspect-agent-safety",
+        source_type="external_provider",
+        adapter_name="inspect",
+        adapter_version="0.3.0",
+        result_contract_version="1.0.0",
+    )
+
+    assert registration.evaluator_id == "inspect-agent-safety"
+    assert registration.source_types == frozenset({"external_provider", "fairmind_worker"})
+    assert len(registry.catalog_hash) == 64
+    assert (
+        registry.catalog_hash
+        == StaticEvaluatorRegistry(
+            catalog_version="2026.08.1",
+            registrations=(registration,),
+        ).catalog_hash
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected_code"),
+    (
+        ("evaluator_id", "unknown-evaluator", "evaluator_unregistered"),
+        ("source_type", "imported_report", "evaluator_source_not_allowed"),
+        ("adapter_name", "garak", "evaluator_binding_mismatch"),
+        ("adapter_version", "9.9.9", "evaluator_binding_mismatch"),
+        ("result_contract_version", "2.0.0", "evaluator_binding_mismatch"),
+    ),
+)
+def test_registry_rejects_unknown_or_mismatched_binding(
+    field: str,
+    value: str,
+    expected_code: str,
+) -> None:
+    registry = _registry()
+    binding = {
+        "evaluator_id": "inspect-agent-safety",
+        "source_type": "external_provider",
+        "adapter_name": "inspect",
+        "adapter_version": "0.3.0",
+        "result_contract_version": "1.0.0",
+    }
+    binding[field] = value
+
+    with pytest.raises(EvaluatorRegistryError) as caught:
+        registry.validate_binding(**binding)
+
+    assert caught.value.code == expected_code
+
+
+def test_registry_rejects_inactive_evaluators_and_duplicate_ids() -> None:
+    with pytest.raises(EvaluatorRegistryError, match="not active"):
+        _registry(status="revoked").validate_binding(
+            evaluator_id="inspect-agent-safety",
+            source_type="external_provider",
+            adapter_name="inspect",
+            adapter_version="0.3.0",
+            result_contract_version="1.0.0",
+        )
+
+    registration = EvaluatorRegistration(
+        evaluator_id="inspect-agent-safety",
+        adapter_name="inspect",
+        adapter_version="0.3.0",
+        result_contract_version="1.0.0",
+        source_types=frozenset({"external_provider"}),
+    )
+    with pytest.raises(EvaluatorRegistryError, match="duplicate"):
+        StaticEvaluatorRegistry(
+            catalog_version="2026.08.1",
+            registrations=(registration, registration),
+        )

--- a/apps/backend/tests/test_verified_evidence_admission_postgres.py
+++ b/apps/backend/tests/test_verified_evidence_admission_postgres.py
@@ -715,6 +715,10 @@ def _verified_service(
     from src.application.services.verified_evidence_admission_service import (
         VerifiedEvidenceAdmissionService,
     )
+    from src.application.services.evaluator_registry import (
+        EvaluatorRegistration,
+        StaticEvaluatorRegistry,
+    )
 
     unit_of_work = SqlAlchemyEvaluationWorkbenchUnitOfWork(
         session,
@@ -723,6 +727,18 @@ def _verified_service(
     return VerifiedEvidenceAdmissionService(
         unit_of_work,
         EvidenceAuthenticityService(verifier or Ed25519EvidenceVerifier()),
+        StaticEvaluatorRegistry(
+            catalog_version="2026.08.1",
+            registrations=(
+                EvaluatorRegistration(
+                    evaluator_id="inspect-postgres-evaluator",
+                    adapter_name="inspect",
+                    adapter_version="0.3.0",
+                    result_contract_version="1.0.0",
+                    source_types=frozenset({"external_provider"}),
+                ),
+            ),
+        ),
     )
 
 

--- a/apps/backend/tests/test_verified_evidence_admission_service.py
+++ b/apps/backend/tests/test_verified_evidence_admission_service.py
@@ -29,6 +29,10 @@ from src.application.services.evidence_authenticity_service import (
     AuthenticityCandidate,
     EvidenceAuthenticityError,
 )
+from src.application.services.evaluator_registry import (
+    EvaluatorRegistration,
+    StaticEvaluatorRegistry,
+)
 from src.application.services.verified_evidence_admission_service import (
     VerifiedEvidenceAdmissionService,
 )
@@ -422,6 +426,7 @@ def _configured_service(
     first_hash: str = "9" * 64,
     second_hash: str = "9" * 64,
     authenticity_failure: Exception | None = None,
+    evaluator_registry: StaticEvaluatorRegistry | None = None,
 ):
     initial = authority or _authority()
     verified = second_authority or initial
@@ -437,6 +442,19 @@ def _configured_service(
     service = VerifiedEvidenceAdmissionService(
         unit_of_work,
         authenticity,  # type: ignore[arg-type]
+        evaluator_registry=evaluator_registry
+        or StaticEvaluatorRegistry(
+            catalog_version="2026.08.1",
+            registrations=(
+                EvaluatorRegistration(
+                    evaluator_id="evaluator-a",
+                    adapter_name="inspect",
+                    adapter_version="0.3.0",
+                    result_contract_version="1.0.0",
+                    source_types=frozenset({"external_provider"}),
+                ),
+            ),
+        ),
         uuid_factory=SequentialUuidFactory(),
     )
     service._resolver = resolver
@@ -551,7 +569,38 @@ def test_verified_admission_persists_exact_graph_with_fresh_database_time() -> N
         "freshnessStatus": "current",
         "runTechnicalStatus": "succeeded",
         "runEvidenceOutcome": "failed",
+        "evaluatorRegistryHash": "e816008e154dd1c5509c2158ca1e0ff0f40a8f75c209a22f2d473fc375e5c617",
+        "evaluatorRegistrationHash": "eba56d312a0fe0e4ce7e6af6bc4b20b4660f75da7d4accc343772ea9298d62c3",
     }
+
+
+def test_signed_evaluator_must_be_registered_by_server_catalog() -> None:
+    service, unit_of_work, repository, _, _ = _configured_service(
+        evaluator_registry=StaticEvaluatorRegistry(
+            catalog_version="2026.08.1",
+            registrations=(
+                EvaluatorRegistration(
+                    evaluator_id="different-evaluator",
+                    adapter_name="inspect",
+                    adapter_version="0.3.0",
+                    result_contract_version="1.0.0",
+                    source_types=frozenset({"external_provider"}),
+                ),
+            ),
+        )
+    )
+
+    with pytest.raises(EvaluationWorkbenchError) as caught:
+        service.admit_verified_passport_v2(
+            scope=SCOPE,
+            actor_id="reviewer-a",
+            idempotency_key="unregistered-evaluator-a",
+            raw_passport=_passport_bytes(),
+        )
+
+    assert caught.value.code == "evidence_evaluator_unregistered"
+    assert repository.persisted == []
+    assert unit_of_work.rejections == [caught.value]
 
 
 @pytest.mark.parametrize(

--- a/docs/architecture/verified-evidence-admission-task12b.md
+++ b/docs/architecture/verified-evidence-admission-task12b.md
@@ -21,12 +21,15 @@ The submitted Passport supplies an issuer key and signing-key identifier only
 as lookup selectors. It cannot supply authoritative target, plan, suite,
 envelope, policy, issuer, or key state.
 
-`evaluatorId` is signed, stored, and receipt-bound, but Task 12B still treats it
-as an issuer assertion. The server independently authorizes the issuer, source,
-adapter name and version, and result-contract version; it does not yet resolve
-`evaluatorId` through a server-owned evaluator registry. Product claims must
-not describe evaluator identity as independently authorized until that catalog
-and binding ceremony exist.
+`evaluatorId` is signed, stored, and receipt-bound. The internal admission
+kernel now resolves it through an immutable, server-owned evaluator catalog and
+requires the catalog entry to match source, adapter name/version, and result
+contract exactly. The catalog hash and registration hash are included in the
+append-only successful-admission audit event. This is an in-process catalog for
+the current default-off slice: persistent catalog administration, external and
+FairMind-worker registration ceremonies, and route-level catalog permissions
+remain separate release gates. Product claims must not describe an evaluator or
+provider as generally authorized until those gates exist.
 
 Inside the organization-scoped mutation transaction, the trusted resolver:
 

--- a/docs/architecture/verified-evidence-admission-task12b.md
+++ b/docs/architecture/verified-evidence-admission-task12b.md
@@ -1,6 +1,7 @@
 # Verified Evidence Passport V2 admission
 
-Status: internal application kernel; default-off and not route-wired
+Status: internal application kernel; route-composed but independently
+default-off
 
 ## Purpose
 
@@ -159,10 +160,32 @@ errors, and unexpected post-write exceptions remain 500-class persistence
 failures and roll back the graph, idempotency row, and audit event. This avoids
 mislabeling infrastructure failure as a trustworthy user rejection.
 
+## HTTP boundary
+
+The verified-admission endpoint is mounted only when both the assurance-v2
+flag and the independent evidence-submit flag are enabled:
+
+`POST /api/v1/ai-governance/organizations/{org_id}/workspaces/{workspace_id}/systems/{system_id}/evaluation-v2/runs/{run_id}/suite-executions/{suite_execution_id}/evidence`
+
+The route requires the organization role permission
+`evaluation:evidence:submit`. It binds the organization, workspace, system,
+run, and suite execution path identities to the same immutable run projection
+before reading the request body. It accepts only JSON media types and streams
+at most the existing one-MiB request limit; the admission service receives the
+raw bytes so canonical Passport parsing and authentication remain authoritative
+inside the application transaction. Missing permission, any scope mismatch,
+unsupported media type, and oversized bodies fail before an admission call.
+
+The production composition uses real Ed25519 verification and the existing
+transactional admission service, but its bootstrap evaluator registry is empty.
+Therefore a flag-enabled deployment still rejects every evaluator as
+unregistered until server-owned evaluator registration persistence and
+approval ceremonies are released.
+
 ## Capability boundary
 
-Task 12B deliberately adds no API route, permission wiring, UI, worker,
-external-provider registration ceremony, unsigned-import flow, reviewer action,
+Task 12B deliberately adds no UI, worker, external-provider registration
+ceremony, unsigned-import flow, reviewer action,
 governance decision, framework mapping, certification, compliance claim, or
 runtime enforcement. The kernel remains internal and default-off until its
 native PostgreSQL adversarial suite, independent security review, and later

--- a/docs/superpowers/plans/2026-08-08-task12b-release-gate-backlog.md
+++ b/docs/superpowers/plans/2026-08-08-task12b-release-gate-backlog.md
@@ -21,16 +21,19 @@ kernel; none of these rows authorize route exposure or a product claim.
   identity through local admission scope and restriction checks, and prove zero
   evidence graph and zero successful admission audit in both tenants.
 
-## Before any evidence-admission route is composed
+## Before any evidence-admission route is enabled
 
 - [x] Add an immutable in-process server-owned evaluator registry and bind the
   signed `evaluatorId` to an active, exact source/adapter/result-contract
   tuple. The catalog and registration hashes are recorded in the append-only
   admission audit event. Persistent catalog administration and provider/worker
   registration ceremonies remain separate release gates.
-- [ ] Add the route-level `evaluation:evidence:submit` permission, exact
-  organization/workspace/system/run/suite scope checks, request byte limits,
-  feature flag, and service composition as a separately reviewed change.
+- [x] Compose the default-off route-level `evaluation:evidence:submit`
+  permission, exact organization/workspace/system/run/suite scope checks,
+  bounded request streaming, an independently gated API router, and the
+  server-owned admission service. The bootstrap composition has an empty
+  evaluator catalog, so accidentally enabling the route still rejects every
+  evaluator as unregistered until registration ceremonies are released.
 - [ ] Keep admission distinct from reviewer acceptance, governance decision,
   framework evidence acceptance, certification, compliance, and enforcement.
 - [ ] Add real external-provider and FairMind-worker registration ceremonies;

--- a/docs/superpowers/plans/2026-08-08-task12b-release-gate-backlog.md
+++ b/docs/superpowers/plans/2026-08-08-task12b-release-gate-backlog.md
@@ -23,10 +23,11 @@ kernel; none of these rows authorize route exposure or a product claim.
 
 ## Before any evidence-admission route is composed
 
-- [ ] Add a server-owned evaluator registry and bind signed `evaluatorId` to an
-  authorized evaluator version. Task 12B currently treats that identifier as a
-  signed issuer assertion while independently authorizing issuer, source,
-  adapter, adapter version, and result-contract version.
+- [x] Add an immutable in-process server-owned evaluator registry and bind the
+  signed `evaluatorId` to an active, exact source/adapter/result-contract
+  tuple. The catalog and registration hashes are recorded in the append-only
+  admission audit event. Persistent catalog administration and provider/worker
+  registration ceremonies remain separate release gates.
 - [ ] Add the route-level `evaluation:evidence:submit` permission, exact
   organization/workspace/system/run/suite scope checks, request byte limits,
   feature flag, and service composition as a separately reviewed change.

--- a/docs/superpowers/plans/2026-08-08-task12b-release-gate-backlog.md
+++ b/docs/superpowers/plans/2026-08-08-task12b-release-gate-backlog.md
@@ -51,16 +51,14 @@ kernel; none of these rows authorize route exposure or a product claim.
 
 ## Repository baseline debt
 
-- [ ] Repair the pre-existing backend collection failure in
-  `tests/test_fairness_evidence_profile_route.py`, which imports the absent
-  compatibility module `api.models.ai_bom`.
-- [ ] Remove the order-dependent SQLAlchemy metadata collision caused by two
-  active `AuditLog` declarations for `audit_logs` in
-  `src/api/middleware/audit_logging.py` and
-  `src/infrastructure/db/database/models.py`. In the broad suite this can
-  attempt to create `ix_audit_logs_user_id` twice; an affected governance test
-  passes when isolated, so this is test/runtime model-composition debt rather
-  than a Task 12B regression.
+- [x] Repair the pre-existing backend collection failure in
+  `tests/test_fairness_evidence_profile_route.py`: the active
+  `api.models.ai_bom` compatibility transport models now restore the route's
+  request/response boundary without an archive dependency.
+- [x] Remove the order-dependent SQLAlchemy metadata collision caused by two
+  active `AuditLog` declarations for `audit_logs`: the middleware now reexports
+  the canonical `database.models.AuditLog`, so the user index has one owner in
+  every import order.
 - [ ] Establish a clean whole-backend CI baseline after those two blockers are
   resolved. Until then, use focused affected suites plus native PostgreSQL,
   boundary, archive-import, formatting, and diff checks as the Task 12B gate.


### PR DESCRIPTION
## Summary

Adds the next internal P0 trust-gate slice after the merged evidence foundation:

- Adds an immutable server-owned evaluator registry with catalog hashing.
- Requires the signed evaluator ID, delivery source, adapter name/version, and result contract to match an active server registration.
- Rejects unknown, inactive, source-incompatible, or mismatched evaluator bindings before persistence.
- Records the catalog and registration hashes in the append-only successful-admission audit event.
- Keeps the registry in-process and route-free; persistent catalog administration, provider/worker registration ceremonies, permissions, and public claims remain gated.

## Validation

- 23 focused evaluator/admission tests passed.
- PostgreSQL admission suite is present but skipped locally because the PostgreSQL test service is unavailable.
- Backend layer-boundary check passed.
- No-archive-import check passed.
- Black checks passed for changed production and new test modules.
- This is not a production release and does not expose an evidence-admission route.